### PR TITLE
Quick wins: Case-insensitive search, consistent entity marker z-height, and new waypoint colour randomised when not provided

### DIFF
--- a/src/main/java/com/eerussianguy/blazemap/api/markers/Waypoint.java
+++ b/src/main/java/com/eerussianguy/blazemap/api/markers/Waypoint.java
@@ -12,10 +12,12 @@ public class Waypoint extends Marker<Waypoint> {
 
     public Waypoint(ResourceLocation id, ResourceKey<Level> dimension, BlockPos position, String name) {
         this(id, dimension, position, name, BlazeMapReferences.Icons.WAYPOINT, -1, 0);
+        this.randomizeColor();
     }
 
     public Waypoint(ResourceLocation id, ResourceKey<Level> dimension, BlockPos position, String name, ResourceLocation icon) {
         this(id, dimension, position, name, icon, -1, 0);
+        this.randomizeColor();
     }
 
     public Waypoint(ResourceLocation id, ResourceKey<Level> dimension, BlockPos position, String name, ResourceLocation icon, int color) {

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -123,6 +124,7 @@ public class MapRenderer implements AutoCloseable {
     private double zoom = 1;
     private TileResolution resolution;
     private final boolean renderNames;
+    private final double playerMarkerZHeight = 1;
 
     public MapRenderer(int width, int height, ResourceLocation textureResource, double minZoom, double maxZoom, boolean renderNames) {
         this.center = new BlockPos.MutableBlockPos();
@@ -329,7 +331,7 @@ public class MapRenderer implements AutoCloseable {
             }
         }
         LocalPlayer player = Helpers.getPlayer();
-        renderMarker(buffers, graphics, player.blockPosition(), PLAYER, Colors.NO_TINT, 32, 32, player.getRotationVector().y, false, null, SearchTargeting.NONE);
+        renderMarker(buffers, graphics, player.blockPosition(), PLAYER, Colors.NO_TINT, 32, 32, playerMarkerZHeight, player.getRotationVector().y, false, null, SearchTargeting.NONE);
         stack.popPose();
 
         stack.popPose();
@@ -338,9 +340,15 @@ public class MapRenderer implements AutoCloseable {
     private void renderEntities(GuiGraphics graphics, MultiBufferSource buffers) {
         Minecraft mc = Minecraft.getInstance();
         LocalPlayer player = mc.player;
+        Random zHeightGenerator = new Random();
         mc.level.entitiesForRendering().forEach(entity -> {
             if(!(entity instanceof LivingEntity)) return;
             BlockPos pos = entity.blockPosition();
+
+            // Get a *consistent* random value for each entity to avoid appearance of z-fighting
+            zHeightGenerator.setSeed(entity.getUUID().getMostSignificantBits());
+            double zHeight = zHeightGenerator.nextDouble();
+
             if(inRange(pos)) {
                 int color;
                 boolean isPlayer = false;
@@ -369,7 +377,7 @@ public class MapRenderer implements AutoCloseable {
                     return;
                 }
 
-                renderMarker(buffers, graphics, pos, PLAYER, color, 32, 32, entity.getRotationVector().y, false, isPlayer ? entity.getName().getString() : null, SearchTargeting.NONE);
+                renderMarker(buffers, graphics, pos, PLAYER, color, 32, 32, zHeight, entity.getRotationVector().y, false, isPlayer ? entity.getName().getString() : null, SearchTargeting.NONE);
             }
         });
     }
@@ -445,29 +453,40 @@ public class MapRenderer implements AutoCloseable {
     }
 
     private void renderMarker(MultiBufferSource buffers, GuiGraphics graphics, BlockPos position, ResourceLocation marker, int color, double width, double height, float rotation, boolean zoom, String name, SearchTargeting search) {
+        renderMarker(buffers, graphics, position, marker, color, width, height, 0, rotation, zoom, name, search);
+    }
+
+
+    private void renderMarker(MultiBufferSource buffers, GuiGraphics graphics, BlockPos position, ResourceLocation marker, int color, double width, double height, double zHeight, float rotation, boolean zoom, String name, SearchTargeting search) {
         PoseStack stack = graphics.pose();
 
         stack.pushPose();
+
         stack.scale((float) this.zoom, (float) this.zoom, 1);
         int dx = position.getX() - begin.getX();
         int dy = position.getZ() - begin.getZ();
         stack.translate(dx, dy, 0);
+
         if(!zoom) {
             stack.scale(1F / (float) this.zoom, 1F / (float) this.zoom, 1);
         }
+
         if(name != null) {
             float scale = 2;
             Minecraft mc = Minecraft.getInstance();
+
             stack.pushPose();
-            stack.translate(-mc.font.width(name), (10 + (height / scale)), 0);
+            stack.translate(-mc.font.width(name), (10 + (height / scale)), zHeight);
             stack.scale(scale, scale, 0);
             mc.font.drawInBatch(name, 0, 0, search.color(color), true, stack.last().pose(), buffers, Font.DisplayMode.NORMAL, 0, LightTexture.FULL_BRIGHT);
             stack.popPose();
         }
+
         stack.mulPose(Axis.ZP.rotationDegrees(rotation));
-        stack.translate(-width / 2, -height / 2, 0);
+        stack.translate(-width / 2, -height / 2, zHeight);
         VertexConsumer vertices = buffers.getBuffer(RenderType.text(marker));
         RenderHelper.drawQuad(vertices, stack.last().pose(), (float) width, (float) height, search.color(color));
+
         stack.popPose();
     }
 

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
@@ -524,7 +524,7 @@ public class MapRenderer implements AutoCloseable {
             matcher = pattern.asPredicate();
         }
         catch(PatternSyntaxException pse) {
-            matcher = (s) -> s.contains(search);
+            matcher = (s) -> s.toLowerCase().contains(search.toLowerCase());
         }
         hasActiveSearch = true;
         labels.forEach(this::matchLabel);

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
@@ -501,7 +501,7 @@ public class MapRenderer implements AutoCloseable {
             return;
         }
         try {
-            Pattern pattern = Pattern.compile(search);
+            Pattern pattern = Pattern.compile(search, Pattern.CASE_INSENSITIVE);
             matcher = pattern.asPredicate();
         }
         catch(PatternSyntaxException pse) {

--- a/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointManagerGui.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointManagerGui.java
@@ -12,7 +12,6 @@ import com.eerussianguy.blazemap.gui.BlazeGui;
 import com.eerussianguy.blazemap.gui.SelectionList;
 import com.eerussianguy.blazemap.util.Helpers;
 import com.eerussianguy.blazemap.util.RenderHelper;
-import com.mojang.blaze3d.vertex.PoseStack;
 
 public class WaypointManagerGui extends BlazeGui {
     private static IMarkerStorage<Waypoint> waypointStorage;


### PR DESCRIPTION
Some quick wins:

* https://blazemap.atlassian.net/browse/BME-114
* https://blazemap.atlassian.net/browse/BME-93
* https://blazemap.atlassian.net/browse/BME-124