### PR TITLE
BME-13 Fixed BlockColorCollector collecting the wrong blocks + updated README for 1.20.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,22 @@ have the mapping run purely client side.
 
 ## For Contributors
 
-To build Blaze Map locally, make sure to have a copy of the Rubidium binary stored under `/libs`.
-This is because Rubidium is a build time dependency, even if only an optional runtime dependency.
+To build Blaze Map locally, make sure to have a copy of the Embeddium binary stored under `/libs`.
+This is because Embeddium is a build time dependency, even if only an optional runtime dependency.
 
-You can see what version of the Rubidium binary is needed by looking at which version is listed 
+You can see what version of the Embeddium binary is needed by looking at which version is listed
 in `build.gradle`.
 
 ### Local Dev
+
+To set up your IDE to be able to access the deobfuscated Minecraft classes, make sure your IDE
+is configured for both Java 17 and Gradle and then run the setup applicable to your IDE:
+
+```powershell
+gradlew genEclipseRuns
+gradlew genIntellijRuns
+gradlew genVSCodeRuns
+```
 
 To build and run the local dev server in single player mode (client with integrated server):
 
@@ -29,15 +38,6 @@ To build and run just the server:
 
 ```powershell
 gradlew runServer
-```
-
-To set up your IDE to be able to access the deobfuscated Minecraft classes, make sure your IDE
-is configured for both Java 17 and Gradle and then run the setup applicable to your IDE:
-
-```powershell
-gradlew genEclipseRuns
-gradlew genIntellijRuns
-gradlew genVSCodeRuns
 ```
 
 To view all available commands:
@@ -73,3 +73,20 @@ the mixed in version of each `.class` to `.mixin.out` in that instance's folder:
 ```
 -Dmixin.debug.export=true -Dmixin.debug.verbose=true -Dmixin.debug.countInjections=true 
 ```
+
+### Running Client Side Only
+
+To easily start a local Minecraft server with Forge for the sake of testing how Blaze Map works when
+_only_ installed client side, you can spin up a local server in docker with the following:
+
+```powershell
+# Replace <minecraft-version> with your desired Minecraft version, eg 1.20.1
+docker run -it -p 25565:25565 -e EULA=TRUE -e VERSION=<minecraft-version> -e TYPE=FORGE itzg/minecraft-server
+```
+
+Note that to log into this server, you will need to be authenticated. You can either look up how
+to do this with `gradlew runClient` or just build the prod jar as outlined above and launch the
+game via your modded launcher as per usual.
+
+There are other ways you can start up a local Minecraft server too of course, but this is one of
+the simplest.

--- a/src/main/java/com/eerussianguy/blazemap/feature/mapping/BlockColorCollector.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/mapping/BlockColorCollector.java
@@ -2,6 +2,7 @@ package com.eerussianguy.blazemap.feature.mapping;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.core.BlockPos.MutableBlockPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.Heightmap;
@@ -24,7 +25,7 @@ public class BlockColorCollector extends ClientOnlyCollector<BlockColorMD> {
     public BlockColorMD collect(Level level, int minX, int minZ, int maxX, int maxZ) {
         final int[][] colors = new int[16][16];
         final BlockColors blockColors = Minecraft.getInstance().getBlockColors();
-
+        final MutableBlockPos colorPOS = new MutableBlockPos();
 
         for(int x = 0; x < 16; x++) {
             for(int z = 0; z < 16; z++) {
@@ -32,20 +33,29 @@ public class BlockColorCollector extends ClientOnlyCollector<BlockColorMD> {
 
                 int color = -1;
                 while(color == 0 || color == -1) {
-                    POS.set(x + minX, y, z + minZ);
-                    final BlockState state = level.getBlockState(POS);
-                    color = blockColors.getColor(state, level, POS, 0);
+                    colorPOS.set(x + minX, y, z + minZ);
+                    final BlockState state = level.getBlockState(colorPOS);
+
+                    if (state.isAir()) {
+                        y--;
+                        continue;
+                    }
+
+                    color = blockColors.getColor(state, level, colorPOS, 0);
                     if(color <= 0) {
-                        MapColor mapColor = state.getMapColor(level, POS);
+                        MapColor mapColor = state.getMapColor(level, colorPOS);
                         if(mapColor != MapColor.NONE) {
                             color = mapColor.col;
                         }
                     }
+
                     y--;
+
                     if(y <= level.getMinBuildHeight()) {
                         break;
                     }
                 }
+
                 if(color != 0 && color != -1) {
                     colors[x][z] = color;
                 }

--- a/src/main/java/com/eerussianguy/blazemap/feature/mapping/TerrainSlopeCollector.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/mapping/TerrainSlopeCollector.java
@@ -1,6 +1,5 @@
 package com.eerussianguy.blazemap.feature.mapping;
 
-import com.eerussianguy.blazemap.BlazeMap;
 import com.eerussianguy.blazemap.api.BlazeMapReferences;
 import com.eerussianguy.blazemap.api.builtin.TerrainSlopeMD;
 import com.eerussianguy.blazemap.api.pipeline.Collector;

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/Coordination.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/Coordination.java
@@ -14,8 +14,13 @@ public class Coordination {
         mousePixelX = mouseX;
         mousePixelY = mouseY;
 
-        blockX = (int) (beginX + (mouseX / zoom));
-        blockZ = (int) (beginZ + (mouseY / zoom));
+        if (zoom >= 1) {
+            blockX = (beginX + (mouseX / (int)zoom));
+            blockZ = (beginZ + (mouseY / (int)zoom));
+        } else {
+            blockX = (int) (beginX + (mouseX / zoom));
+            blockZ = (int) (beginZ + (mouseY / zoom));
+        }
         chunkX = blockX >> 4;
         chunkZ = blockZ >> 4;
         regionX = chunkX >> 5;


### PR DESCRIPTION
I believe this should be BME-13 completed. Or at least, I can't force it to happen on my machine anymore, so same thing right? 😛

Because the collector was using a shared `MutableBlockPos`, it was occasionally checking blocks from the wrong location. Am not sure why this is the case as LF said the Collectors shouldn't be run in parallel, but giving each collection function its own `MutableBlockPos` has prevented this error from reoccuring.

Also updated the README to refer to Embeddium instead of Rubidium as the dependency to compile against, as well as adding instructions on how to set up a local Forge server for client side only testing (since I had to look up how to do that last night).