### PR TITLE
HOTFIX Can render chunks with exposed void (such as The End)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
 
-version = '0.5.16-beta'
+version = '0.5.17-beta'
 group = 'com.eerussianguy.blazemap' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "BlazeMap-${minecraft_version}"
 

--- a/src/main/java/com/eerussianguy/blazemap/engine/cache/RegionMDCache.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/cache/RegionMDCache.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import net.minecraft.world.level.ChunkPos;
 
+import com.eerussianguy.blazemap.BlazeMap;
 import com.eerussianguy.blazemap.api.util.MinecraftStreams;
 import com.eerussianguy.blazemap.api.util.RegionPos;
 import com.eerussianguy.blazemap.engine.async.DebouncingDomain;
@@ -32,7 +33,7 @@ public class RegionMDCache {
         return dirty;
     }
 
-    public void read(MinecraftStreams.Input stream) throws IOException {
+    public void read(MinecraftStreams.Input stream) {
         try {
             lock.lock();
             for(int index = 0; index < chunks.length; index++) {
@@ -47,8 +48,9 @@ public class RegionMDCache {
                 }
             }
             dirty = false;
-        }
-        finally {
+        } catch (IOException e) {
+            BlazeMap.LOGGER.error("Could not read chunk MD cache file. Skipping.", e);
+        } finally {
             lock.unlock();
         }
     }

--- a/src/main/java/com/eerussianguy/blazemap/feature/mapping/BlockColorCollector.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/mapping/BlockColorCollector.java
@@ -31,8 +31,8 @@ public class BlockColorCollector extends ClientOnlyCollector<BlockColorMD> {
             for(int z = 0; z < 16; z++) {
                 int y = level.getHeight(Heightmap.Types.MOTION_BLOCKING, minX + x, minZ + z);
 
-                int color = -1;
-                while(color == 0 || color == -1) {
+                int color = 0;
+                while(color == 0 && y > level.getMinBuildHeight()) {
                     colorPOS.set(x + minX, y, z + minZ);
                     final BlockState state = level.getBlockState(colorPOS);
 
@@ -50,10 +50,6 @@ public class BlockColorCollector extends ClientOnlyCollector<BlockColorMD> {
                     }
 
                     y--;
-
-                    if(y <= level.getMinBuildHeight()) {
-                        break;
-                    }
                 }
 
                 if(color != 0 && color != -1) {


### PR DESCRIPTION
`BlockColorCollector` had gotten caught in an infinite loop if exposed to the void, thanks to the short-circuiting addition bypassing the check for the bottom of the world height. Have moved the world-ending check to the loop condition itself to ensure it will fail instead.

Also, better hanlded the reading of corrupted MD. Instead of crashing the game, it should now log the fact it couldn't read the file but otherwise continue on as usual. This does have the downside of losing access to that entire cache, but it allows players to continue playing, albeit with a slight performance penalty.

Rendering the Void: Vanilla
![2024-05-24_19 15 43](https://github.com/LordFokas/BlazeMap/assets/12166027/bb749dfa-88bf-4d59-a084-3c1e6eaad1bf)

Rendering the Void: Rubidium
![2024-05-24_19 27 23](https://github.com/LordFokas/BlazeMap/assets/12166027/3169200d-d09c-4019-a904-5f803880adab)
