### PR TITLE
BME-128 Optimising thread locking to avoid contention while fixing IO…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 apply plugin: 'maven-publish'
 
-version = '0.5.17-beta'
+version = '0.5.18-beta'
 group = 'com.eerussianguy.blazemap' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "BlazeMap-${minecraft_version}"
 

--- a/src/main/java/com/eerussianguy/blazemap/engine/StorageAccess.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/StorageAccess.java
@@ -7,9 +7,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import net.minecraft.resources.ResourceLocation;
 
+import com.eerussianguy.blazemap.BlazeMap;
 import com.eerussianguy.blazemap.api.maps.TileResolution;
 import com.eerussianguy.blazemap.api.util.IStorageAccess;
 import com.eerussianguy.blazemap.api.util.MinecraftStreams;
@@ -83,6 +86,8 @@ public class StorageAccess implements IStorageAccess {
     public static class Internal extends StorageAccess {
         private static final String PATTERN = "[%s] %s";
         private static final String PATTERN_MIP = "[%s] %s [%d]";
+        private static final String PATTERN_OLD = "%s+%s";
+        private static final Pattern PATTERN_OLD_REGEX = Pattern.compile("^([a-z0-9_]+)\\+([a-z0-9_]+)$");
 
         public Internal(File dir, String child) {
             this(new File(dir, child));
@@ -106,6 +111,42 @@ public class StorageAccess implements IStorageAccess {
             File d = new File(dir, String.format(PATTERN_MIP, node.getNamespace(), node.getPath(), resolution.pixelWidth));
             d.mkdirs();
             return new File(d, file);
+        }
+
+        /**
+         * Port files from their v0.4 location to their v0.5 location
+         */
+        public void tryPortDimension(ResourceLocation node) throws IOException {
+            Objects.requireNonNull(node);
+            File newFile = getFile(node).getParentFile();
+
+            if ( !newFile.exists() ||
+                (newFile.isDirectory() && newFile.list().length == 0))
+            {
+                File oldFile = new File(dir.getParent(), String.format(PATTERN_OLD, node.getNamespace(), node.getPath()));
+                oldFile.getParentFile().mkdirs();
+
+                if (oldFile.exists()) {
+                    move(oldFile, newFile);
+
+                    File[] layers = newFile.listFiles();
+                    for (File layer : layers) {
+                        portLayer(layer);
+                    }
+                }
+            }
+        }
+
+        public void portLayer(File oldFile) throws IOException {
+            String oldFilename = oldFile.getName();
+            Matcher matcher = PATTERN_OLD_REGEX.matcher(oldFilename);
+
+            if (matcher.matches()) {
+                File newFile = new File(dir, String.format(PATTERN_MIP, matcher.group(1), matcher.group(2), TileResolution.FULL.pixelWidth));
+                newFile.mkdirs();
+
+                move(oldFile, newFile);
+            }
         }
 
         public StorageAccess addon() {

--- a/src/main/java/com/eerussianguy/blazemap/engine/cache/ChunkMDCache.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/cache/ChunkMDCache.java
@@ -2,6 +2,8 @@ package com.eerussianguy.blazemap.engine.cache;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 
 import com.eerussianguy.blazemap.BlazeMap;
 import com.eerussianguy.blazemap.api.BlazeMapAPI;
@@ -13,39 +15,84 @@ import com.eerussianguy.blazemap.engine.UnsafeGenerics;
 
 public class ChunkMDCache {
     protected final Map<BlazeRegistry.Key<DataType>, MasterDatum> data = new TreeMap<>(Comparator.comparing(o -> o.location));
+    protected volatile boolean dirty = false;
+
+    protected final ReentrantReadWriteLock cacheLock = new ReentrantReadWriteLock();
+    protected final ReentrantReadWriteLock.ReadLock rLock = cacheLock.readLock();
+    protected final ReentrantReadWriteLock.WriteLock wLock = cacheLock.writeLock();
+
 
     public MasterDatum get(BlazeRegistry.Key<DataType> key) {
-        return data.get(key);
+        rLock.lock();
+        try {
+            return data.get(key);
+
+        } finally {
+            rLock.unlock();
+        }
     }
 
     public boolean update(MasterDatum datum) {
         BlazeRegistry.Key<DataType> key = UnsafeGenerics.stripKey(datum.getID());
-        MasterDatum old = data.get(key);
-        if(!datum.equals(old)) {
-            data.put(key, datum);
-            setDirty();
-            return true;
+
+        wLock.lock();
+        try {
+            MasterDatum old = data.get(key);
+
+            if(!datum.equals(old)) {
+                setDirty(true);
+                data.put(key, datum);
+
+                return true;
+            }
+            return false;
+
+        } finally {
+            wLock.unlock();
         }
-        return false;
     }
 
-    protected void setDirty() {}
-
     public boolean isEmpty() {
-        return data.isEmpty();
+        rLock.lock();
+        try {
+            return data.isEmpty();
+
+        } finally {
+            rLock.unlock();
+        }
     }
 
     public Set<BlazeRegistry.Key<DataType>> keys() {
-        return data.keySet();
+        rLock.lock();
+        try {
+            return data.keySet();
+
+        } finally {
+            rLock.unlock();
+        }
     }
 
     public List<MasterDatum> data() {
-        return data.values().stream().toList();
+        rLock.lock();
+        try {
+            return data.values().stream().toList();
+
+        } finally {
+            rLock.unlock();
+        }
     }
 
     public ChunkMDCache clear() {
-        data.clear();
-        return this;
+        wLock.lock();
+        try {
+            setDirty(true);
+            data.clear();
+
+            return this;
+
+        } finally {
+            wLock.unlock();
+        }
     }
 
     public ChunkMDCache copy() {
@@ -53,9 +100,57 @@ public class ChunkMDCache {
     }
 
     public ChunkMDCache copyInto(ChunkMDCache clone) {
-        clone.data.clear();
-        clone.data.putAll(data);
-        return clone;
+        rLock.lock();
+        clone.wLock.lock();
+
+        try {
+            clone.setDirty(true);
+
+            clone.data.clear();
+            clone.data.putAll(data);
+            return clone;
+
+        } finally {
+            clone.wLock.unlock();
+            rLock.unlock();
+        }
+    }
+
+    /**
+     * Mark this chunk as either "dirty" or "not dirty" (ie "clean").
+     *
+     * A chunk can only be marked dirty if already holding the write lock, however can be marked as
+     * clean from either the read or write lock (eg if cache has been read out to file to save).
+     *
+     * Note: As isDirty() is _not_ protected by the cache lock (though this.dirty is marked volatile to
+     * synchronise its value between threads), placement of calls to setDirty() need to be considered in the
+     * context of providing the most useful value to other threads checking this chunks current cleanliness status
+     * (knowing they won't then be able to act further on this chunk without first acquiring its lock)
+     */
+    protected void setDirty(boolean dirty) {
+        rLock.lock();
+        try {
+            if (dirty && !cacheLock.isWriteLockedByCurrentThread()) {
+                throw new IllegalThreadStateException(
+                    "Trying to mark ChunkMDCache as dirty without holding write lock first. You must hold the write lock before changing the ChunkMDCache."
+                );
+            }
+
+            this.dirty = dirty;
+
+        } finally {
+            rLock.unlock();
+        }
+    }
+
+    /**
+     * Returns if this cache is dirty or not.
+     *
+     * Note that this function is _not_ protected by the chunk lock to improve throughput when checking region cleanliness,
+     * though the underlying value itself is volatile to keep it synchronised across threads
+     */
+    public boolean isDirty() {
+        return dirty;
     }
 
     static class Persisted extends ChunkMDCache {
@@ -65,44 +160,60 @@ public class ChunkMDCache {
             this.parent = parent;
         }
 
+        /**
+         * Read from stream into cache
+         */
         public void read(MinecraftStreams.Input stream) throws IOException {
             int entries = stream.readInt();
 
-            for(int i = 0; i < entries; i++) { // Why can't I just write Key<DataType<>> and have the compiler trust me? ffs.
-                BlazeRegistry.Key<DataType> key = (BlazeRegistry.Key<DataType>) (Object) BlazeMapAPI.MASTER_DATA.findOrCreate(stream.readResourceLocation());
+            // Yes I see the irony that the read() function needs a write lock and the write() function needs a read lock
+            wLock.lock();
+            try {
+                for(int i = 0; i < entries; i++) { // Why can't I just write Key<DataType<>> and have the compiler trust me? ffs.
+                    BlazeRegistry.Key<DataType> key = (BlazeRegistry.Key<DataType>) (Object) BlazeMapAPI.MASTER_DATA.findOrCreate(stream.readResourceLocation());
 
-                if (key.value() == null) {
-                    BlazeMap.LOGGER.warn("Unrecognised DataType in MD cache. Did you uninstall a Blaze Map extension? Skipping cache read");
-                    throw new IOException("Cannot deserialize unregistered MD DataType");
+                    if (key.value() == null) {
+                        BlazeMap.LOGGER.warn("Unrecognised DataType in MD cache. Did you uninstall a Blaze Map extension? Skipping cache read");
+                        throw new IOException("Cannot deserialize unregistered MD DataType");
+                    }
+
+                    data.put(key, key.value().deserialize(stream));
                 }
 
-                data.put(key, key.value().deserialize(stream));
+                // Setting "clean" now the cache matches what's on disk
+                setDirty(false);
+
+            } finally {
+                wLock.unlock();
             }
         }
-
+        /**
+         * Write from cache into stream
+         */
         public void write(MinecraftStreams.Output stream) throws IOException {
-            stream.writeInt(data.size());
-            for(Map.Entry<BlazeRegistry.Key<DataType>, MasterDatum> entry : data.entrySet()) {
-                BlazeRegistry.Key<DataType> key = entry.getKey();
-                stream.writeResourceLocation(key.location);
-                key.value().serialize(stream, entry.getValue());
-            }
-        }
-
-        @Override
-        public boolean update(MasterDatum datum) {
+            rLock.lock();
             try {
-                parent.lock().lock();
-                return super.update(datum);
-            }
-            finally {
-                parent.lock().unlock();
+                stream.writeInt(data.size());
+
+                for(Map.Entry<BlazeRegistry.Key<DataType>, MasterDatum> entry : data.entrySet()) {
+                    BlazeRegistry.Key<DataType> key = entry.getKey();
+
+                    stream.writeResourceLocation(key.location);
+                    key.value().serialize(stream, entry.getValue());
+                }
+
+                // Only set "clean" after everything's been read in case exceptions are thrown while doing so
+                setDirty(false);
+
+            } finally {
+                rLock.unlock();
             }
         }
 
         @Override
-        protected void setDirty() {
-            parent.setDirty();
+        protected void setDirty(boolean dirty) {
+            super.setDirty(dirty);
+            parent.requestSave();
         }
     }
 }

--- a/src/main/java/com/eerussianguy/blazemap/engine/cache/LevelMDCache.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/cache/LevelMDCache.java
@@ -47,13 +47,19 @@ public class LevelMDCache {
                     String file = getFilename(key);
 
                     if(storage.exists(NODE, file)){
+                        // Try to greedily acquire file lock
+                        if (!cache.fileLock.readLock().tryLock()) cache.fileLock.readLock().lock();
+
                         try(MinecraftStreams.Input stream = storage.read(NODE, file)) {
                             cache.read(stream);
-
-                        } catch (Exception e) {
+                        }
+                        catch (Exception e) {
                             // Couldn't populate the cache from the existing cache file (corruption?)
                             // so behaving as if no cache file was found
                             cache = new RegionMDCache(key, debouncer);
+                        }
+                        finally {
+                            cache.fileLock.readLock().unlock();
                         }
                     }
 
@@ -67,21 +73,34 @@ public class LevelMDCache {
         asyncChain.runOnDataThread(() -> {
             String buffer = getBufferFile(cache.pos());
             String file = getFilename(cache.pos());
-            try(MinecraftStreams.Output stream = storage.write(NODE, buffer)) {
-                cache.write(stream);
-            }
-            catch(IOException e) {
-                BlazeMap.LOGGER.warn("Error writing cache buffer {}. Will try again later", buffer);
-                e.printStackTrace();
-                debouncer.push(cache);
-            }
+
+            cache.bufferLock.lock();
             try {
-                storage.move(NODE, buffer, file);
+                try(MinecraftStreams.Output stream = storage.write(NODE, buffer)) {
+                    cache.write(stream);
+                }
+                catch(IOException e) {
+                    BlazeMap.LOGGER.warn("Error writing cache buffer {}. Will try again later", buffer);
+                    e.printStackTrace();
+                    debouncer.push(cache);
+                    return;
+                }
+
+                cache.fileLock.writeLock().lock();
+                try {
+                    storage.move(NODE, buffer, file);
+                }
+                catch(IOException e) {
+                    BlazeMap.LOGGER.warn("Error moving buffer to file {}. Will try again later", file);
+                    e.printStackTrace();
+                    debouncer.push(cache);
+                }
+                finally {
+                    cache.fileLock.writeLock().unlock();
             }
-            catch(IOException e) {
-                BlazeMap.LOGGER.warn("Error moving buffer to file {}. Will try again later", file);
-                e.printStackTrace();
-                debouncer.push(cache);
+            }
+            finally {
+                cache.bufferLock.unlock();
             }
         });
     }

--- a/src/main/java/com/eerussianguy/blazemap/engine/cache/RegionMDCache.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/cache/RegionMDCache.java
@@ -1,6 +1,11 @@
 package com.eerussianguy.blazemap.engine.cache;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.Iterator;
+
 
 import net.minecraft.world.level.ChunkPos;
 
@@ -8,60 +13,64 @@ import com.eerussianguy.blazemap.BlazeMap;
 import com.eerussianguy.blazemap.api.util.MinecraftStreams;
 import com.eerussianguy.blazemap.api.util.RegionPos;
 import com.eerussianguy.blazemap.engine.async.DebouncingDomain;
-import com.eerussianguy.blazemap.engine.async.PriorityLock;
 import com.eerussianguy.blazemap.profiling.Profilers;
 
 public class RegionMDCache {
     private static final int CHUNKS = 0x20;
     private static final byte VOID = 0x00, DATA = 0x01;
 
-    private final ChunkMDCache.Persisted[] chunks = new ChunkMDCache.Persisted[CHUNKS * CHUNKS];
+    private final ChunkCacheStore chunks = new ChunkCacheStore(CHUNKS * CHUNKS);
     private final DebouncingDomain<RegionMDCache> debouncer;
-    private final PriorityLock lock = new PriorityLock();
     private final RegionPos pos;
-    private boolean dirty;
+
+    // These are both invoked at the LevelMDCache level, due to the movement between buffer and file
+    public final ReentrantReadWriteLock fileLock = new ReentrantReadWriteLock();
+    public final ReentrantLock bufferLock = new ReentrantLock();
 
     public RegionMDCache(RegionPos pos, DebouncingDomain<RegionMDCache> debouncer) {
         this.pos = pos;
         this.debouncer = debouncer;
     }
 
-    PriorityLock lock() {
-        return lock;
-    }
-
     public boolean isDirty() {
-        return dirty;
+        for (ChunkMDCache.Persisted chunk : chunks) {
+            if (chunk != null && chunk.isDirty()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void read(MinecraftStreams.Input stream) {
         Profilers.FileOps.CACHE_READ_TIME_PROFILER.begin();
+
         try {
-            lock.lock();
             for(int index = 0; index < chunks.length; index++) {
                 byte b = stream.readByte();
+
                 switch(b) {
                     case VOID: continue;
                     case DATA:
-                        ChunkMDCache.Persisted chunk = chunks[index] = new ChunkMDCache.Persisted(this);
+                        ChunkMDCache.Persisted chunk = chunks.get(index);
                         chunk.read(stream);
                         break;
+
                     default: throw new RuntimeException("Unexpected byte flag: " + b);
                 }
             }
-            dirty = false;
         } catch (IOException e) {
             BlazeMap.LOGGER.error("Could not read region MD cache file. Skipping.", e);
+
         } finally {
-            lock.unlock();
             Profilers.FileOps.CACHE_READ_TIME_PROFILER.end();
         }
     }
 
     public void write(MinecraftStreams.Output stream) throws IOException {
         Profilers.FileOps.CACHE_WRITE_TIME_PROFILER.begin();
+
         try {
-            lock.lockPriority();
             for(ChunkMDCache.Persisted chunk : chunks) {
                 if(chunk == null || chunk.isEmpty()) {
                     stream.writeByte(VOID);
@@ -70,10 +79,8 @@ public class RegionMDCache {
                     chunk.write(stream);
                 }
             }
-            dirty = false;
         }
         finally {
-            lock.unlock();
             Profilers.FileOps.CACHE_WRITE_TIME_PROFILER.end();
         }
     }
@@ -82,26 +89,61 @@ public class RegionMDCache {
         int x = chunk.getRegionLocalX();
         int z = chunk.getRegionLocalZ();
         int index = x * CHUNKS + z;
-        try {
-            lock.lock();
-            synchronized(chunks) {
-                if(chunks[index] == null) {
-                    chunks[index] = new ChunkMDCache.Persisted(this);
-                }
-            }
-        }
-        finally {
-            lock.unlock();
-        }
-        return chunks[index];
+
+        return chunks.get(index);
     }
 
     public RegionPos pos() {
         return pos;
     }
 
-    void setDirty(){
-        this.dirty = true;
+    void requestSave(){
         debouncer.push(this);
+    }
+
+    /**
+     * This is a wrapper for the list of chunk caches to make sure it's threadsafe.
+     *
+     * This is done by not allowing any external set opperations, so each index will only ever return
+     * its originally assigned ChunkMDCache reference. This means read/write safety can be performed on
+     * the individual chunk cache level, avoiding having to lock the whole list.
+     */
+    private class ChunkCacheStore implements Iterable<ChunkMDCache.Persisted> {
+        private final AtomicReferenceArray<ChunkMDCache.Persisted> chunksAtomicArray;
+        public final int length;
+
+        public ChunkCacheStore (int size) {
+            this.chunksAtomicArray = new AtomicReferenceArray<ChunkMDCache.Persisted>(size);
+            this.length = size;
+        }
+
+        public ChunkMDCache.Persisted get(int index) {
+            // The if statement doesn't provide any thread safety, but the compareAndSet does.
+            // The if is only here to minimise the amount of objects unnecessarily created, since the cache
+            // will already exist most of the time, thus minimising GC
+            if (chunksAtomicArray.get(index) == null) {
+                chunksAtomicArray.compareAndSet(index, null, new ChunkMDCache.Persisted(RegionMDCache.this));
+            }
+
+            return chunksAtomicArray.get(index);
+        }
+
+        public Iterator<ChunkMDCache.Persisted> iterator() {
+            return new ChunkCacheIterator();
+        }
+
+        private class ChunkCacheIterator implements Iterator<ChunkMDCache.Persisted> {
+            private int index = 0;
+
+            @Override
+            public boolean hasNext() {
+                return index < length;
+            }
+
+            @Override
+            public ChunkMDCache.Persisted next() {
+                return chunksAtomicArray.get(index++);
+            }
+        }
     }
 }

--- a/src/main/java/com/eerussianguy/blazemap/engine/client/ClientPipeline.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/client/ClientPipeline.java
@@ -59,6 +59,13 @@ class ClientPipeline extends Pipeline {
             BlazeMapAPI.PROCESSORS.keys().stream().filter(k -> k.value().shouldExecuteIn(dimension, type)).collect(Collectors.toUnmodifiableSet())
         );
 
+        // See if need to port data from BM v0.4 or below before doing anything else
+        try {
+            storage.tryPortDimension(dimension.location());
+        } catch (Exception e) {
+            // Do nothing. Don't care.
+        }
+
         // Set up views (immutable sets) for the available maps and layers.
         this.availableMapTypes = BlazeMapAPI.MAPTYPES.keys().stream().filter(m -> m.value().shouldRenderInDimension(dimension)).collect(Collectors.toUnmodifiableSet());
         this.availableLayers = availableMapTypes.stream().map(k -> k.value().getLayers()).flatMap(Set::stream).filter(l -> l.value().shouldRenderInDimension(dimension)).collect(Collectors.toUnmodifiableSet());

--- a/src/main/java/com/eerussianguy/blazemap/engine/client/LayerRegionTile.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/client/LayerRegionTile.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.function.Consumer;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import net.minecraft.world.level.ChunkPos;
 
@@ -14,21 +16,23 @@ import com.eerussianguy.blazemap.api.maps.Layer;
 import com.eerussianguy.blazemap.api.maps.TileResolution;
 import com.eerussianguy.blazemap.api.util.RegionPos;
 import com.eerussianguy.blazemap.engine.StorageAccess;
-import com.eerussianguy.blazemap.engine.async.PriorityLock;
 import com.eerussianguy.blazemap.profiling.Profilers;
 import com.mojang.blaze3d.platform.NativeImage;
 
 public class LayerRegionTile {
     private static final Object MUTEX = new Object();
-    private static int instances = 0, loaded = 0;
+    private static volatile int instances = 0, loaded = 0;
 
-    private final PriorityLock lock = new PriorityLock();
+    private final ReentrantReadWriteLock imageLock = new ReentrantReadWriteLock();
+    private final ReentrantReadWriteLock fileLock = new ReentrantReadWriteLock();
+    private final ReentrantLock bufferLock = new ReentrantLock();
+
     private final File file, buffer;
     private NativeImage image;
     private final TileResolution resolution;
-    private boolean isEmpty = true;
-    private boolean isDirty = false;
-    private boolean destroyed = false;
+    private volatile boolean isEmpty = true;
+    private volatile boolean isDirty = false;
+    private volatile boolean destroyed = false;
 
     public LayerRegionTile(StorageAccess.Internal storage, BlazeRegistry.Key<Layer> layer, RegionPos region, TileResolution resolution) {
         this.file = storage.getMipmap(layer.location, region + ".png", resolution);
@@ -39,7 +43,13 @@ public class LayerRegionTile {
     public void tryLoad() {
         if(file.exists()) {
             Profilers.FileOps.LAYER_READ_TIME_PROFILER.begin();
-            lock.lockPriority();
+
+            // Trying to greedily acquire the locks with `tryLock()` to minimise delay on game thread
+            // TODO: Figure out a "failure" case so the timed tryLock can be used instead to "give up"
+            // if it's waited too long, thereby not blocking the tick
+            if (!fileLock.readLock().tryLock()) fileLock.readLock().lock();
+            if (!imageLock.writeLock().tryLock()) imageLock.writeLock().lock();
+
             try {
                 image = NativeImage.read(Files.newInputStream(file.toPath()));
                 isEmpty = false;
@@ -49,7 +59,8 @@ public class LayerRegionTile {
                 BlazeMap.LOGGER.error("Error loading LayerRegionTile: {}", file, e);
             }
             finally {
-                lock.unlock();
+                imageLock.writeLock().unlock();
+                fileLock.readLock().unlock();
                 Profilers.FileOps.LAYER_READ_TIME_PROFILER.end();
             }
         }
@@ -64,30 +75,40 @@ public class LayerRegionTile {
 
         // Save image into buffer
         Profilers.FileOps.LAYER_WRITE_TIME_PROFILER.begin();
-        lock.lock();
-        try {
-            image.writeToFile(buffer);
-            isDirty = false;
-        }
-        catch(IOException e) {
-            // FIXME: this needs to hook into a reporting mechanism
-            BlazeMap.LOGGER.error("Error saving LayerRegionTile buffer: {}", buffer, e);
-            e.printStackTrace();
-        }
-        finally {
-            lock.unlock();
-            Profilers.FileOps.LAYER_WRITE_TIME_PROFILER.end();
-        }
 
-        // Move buffer to real image path
+        bufferLock.lock();
         try {
-            Files.move(buffer.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            buffer.delete();
-        }
-        catch(IOException e) {
-            // FIXME: this needs to hook into a reporting mechanism
-            BlazeMap.LOGGER.error("Error moving LayerRegionTile buffer to image: {} {}", buffer, file, e);
-            e.printStackTrace();
+            imageLock.readLock().lock();
+            try {
+                image.writeToFile(buffer);
+                isDirty = false;
+            }
+            catch(IOException e) {
+                // FIXME: this needs to hook into a reporting mechanism
+                BlazeMap.LOGGER.error("Error saving LayerRegionTile buffer: {}", buffer, e);
+                e.printStackTrace();
+                return;
+            }
+            finally {
+                imageLock.readLock().unlock();
+            }
+
+            // Move buffer to real image path
+            fileLock.writeLock().lock();
+            try {
+                Files.move(buffer.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            catch(IOException e) {
+                // FIXME: this needs to hook into a reporting mechanism
+                BlazeMap.LOGGER.error("Error moving LayerRegionTile buffer to image: {} {}", buffer, file, e);
+                e.printStackTrace();
+            }
+            finally {
+                fileLock.writeLock().unlock();
+            }
+        } finally {
+            bufferLock.unlock();
+            Profilers.FileOps.LAYER_WRITE_TIME_PROFILER.end();
         }
     }
 
@@ -96,7 +117,11 @@ public class LayerRegionTile {
         int zOffset = (chunk.getRegionLocalZ() << 4) / resolution.pixelWidth;
         boolean wasEmpty = isEmpty;
 
-        lock.lock();
+        // Since isDirty is a volatile bool for thread safety reasons, it's slightly more efficient to only update it once
+        // as updating it flushes the CPU write cache. So using a local var to track dirtiness until final value ready
+        boolean dirty = isDirty;
+
+        imageLock.writeLock().lock();
         try {
             if(isEmpty) {
                 image = new NativeImage(NativeImage.Format.RGBA, resolution.regionWidth, resolution.regionWidth, true);
@@ -109,14 +134,14 @@ public class LayerRegionTile {
                     int pixel = tile.getPixelRGBA(x, z);
                     if(pixel != old) {
                         image.setPixelRGBA(xOffset + x, zOffset + z, pixel);
-                        isDirty = true;
+                        dirty = true;
                     }
                 }
             }
-
         }
         finally {
-            lock.unlock();
+            isDirty = dirty;
+            imageLock.writeLock().unlock();
         }
 
         if(wasEmpty && !isEmpty) {
@@ -130,12 +155,13 @@ public class LayerRegionTile {
 
     public void consume(Consumer<NativeImage> consumer) {
         if(isEmpty) return;
-        lock.lockPriority();
+
+        imageLock.readLock().lock();
         try {
             consumer.accept(image);
         }
         finally {
-            lock.unlock();
+            imageLock.readLock().unlock();
         }
     }
 
@@ -154,33 +180,6 @@ public class LayerRegionTile {
         }
     }
 
-    public void destroy() {
-        if(!destroyed) {
-            synchronized(MUTEX) {
-                instances--;
-                if(!isEmpty) {
-                    loaded -= resolution.regionSizeKb;
-                }
-            }
-        }
-        else return;
-
-        lock.lockPriority();
-        try {
-            save();
-            if(image != null) {
-                image.close();
-                image = null;
-            }
-            isDirty = false;
-            isEmpty = true;
-            destroyed = true;
-        }
-        finally {
-            lock.unlock();
-        }
-    }
-
     public static int getInstances() {
         synchronized(MUTEX) {
             return instances;
@@ -190,6 +189,35 @@ public class LayerRegionTile {
     public static int getLoadedKb() {
         synchronized(MUTEX) {
             return loaded;
+        }
+    }
+
+    public void destroy() {
+        if(destroyed) return;
+
+        // Update static vars
+        synchronized(MUTEX) {
+            instances--;
+            if(!isEmpty) {
+                loaded -= resolution.regionSizeKb;
+            }
+        }
+
+        imageLock.writeLock().lock();
+        try {
+            save();
+
+            if(image != null) {
+                image.close();
+                image = null;
+            }
+
+            isDirty = false;
+            isEmpty = true;
+            destroyed = true;
+        }
+        finally {
+            imageLock.writeLock().unlock();
         }
     }
 }

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/MapRenderer.java
@@ -395,19 +395,22 @@ public class MapRenderer implements AutoCloseable {
         int regionCount = offsets.length * offsets[0].length;
 
         renderTimer.begin();
-        if(regionCount > 4) {
-            debug.stitching = "Parallel";
+        /**
+         * Commenting out the following until the thread pool depletion issue has been solved
+         */
+        // if(regionCount > 6) {
+        //     debug.stitching = "Parallel";
 
-            AsyncAwaiter jobs = new AsyncAwaiter(regionCount);
-            for(int regionIndexX = 0; regionIndexX < offsets.length; regionIndexX++) {
-                for(int regionIndexZ = 0; regionIndexZ < offsets[regionIndexX].length; regionIndexZ++) {
-                    generateMapTileAsync(texture, resolution, textureW, textureH, cornerXOffset, cornerZOffset, regionIndexX, regionIndexZ, jobs);
-                }
-            }
+        //     AsyncAwaiter jobs = new AsyncAwaiter(regionCount);
+        //     for(int regionIndexX = 0; regionIndexX < offsets.length; regionIndexX++) {
+        //         for(int regionIndexZ = 0; regionIndexZ < offsets[regionIndexX].length; regionIndexZ++) {
+        //             generateMapTileAsync(texture, resolution, textureW, textureH, cornerXOffset, cornerZOffset, regionIndexX, regionIndexZ, jobs);
+        //         }
+        //     }
 
-            jobs.await();
-        }
-        else {
+        //     jobs.await();
+        // }
+        // else {
             debug.stitching = "Sequential";
 
             for(int regionIndexX = 0; regionIndexX < offsets.length; regionIndexX++) {
@@ -415,7 +418,7 @@ public class MapRenderer implements AutoCloseable {
                     generateMapTile(texture, resolution, textureW, textureH, cornerXOffset, cornerZOffset, regionIndexX, regionIndexZ);
                 }
             }
-        }
+        // }
         renderTimer.end();
 
         uploadTimer.begin();

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/WorldMapGui.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/WorldMapGui.java
@@ -230,7 +230,6 @@ public class WorldMapGui extends Screen implements IScreenSkipsMinimap, IMapHost
     @Override
     public void render(PoseStack stack, int i0, int i1, float f0) {
         float scale = (float) getMinecraft().getWindow().getGuiScale();
-        fillGradient(stack, 0, 0, this.width, this.height, 0xFF333333, 0xFF333333);
 
         stack.pushPose();
         stack.scale(1F / scale, 1F / scale, 1);


### PR DESCRIPTION
Optimising the thread locking by trying to use read-write locks and threadsafe datastructures to improve throughput of threads. This doesn't entirely eliminate the hitching in game (as the cause of that is thread pool exhaustion) but it significantly reduces it, both in time and in frequency. 