### PR TITLE
BME-46 Fixing the in-world rendering of the waypoint beam

### DIFF
--- a/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
@@ -39,11 +39,15 @@ public class WaypointRenderer {
     public static void onLevelStageRender(RenderLevelStageEvent event) {
         if(!BlazeMapConfig.SERVER.mapItemRequirement.canPlayerAccessMap(Helpers.getPlayer(), ServerConfig.MapAccess.READ_LIVE)) return;
 
+        Minecraft mc = Minecraft.getInstance();
+
+        // Distance to furthest visible block, accounting for default sky fog.
+        float toEdgeOfRenderView = Helpers.getRenderDistance(mc, true);
+
         // Forge Doc:
         // Use this to render custom effects into the world, such as custom entity-like objects or special rendering effects. Called within a fabulous graphics target. Happens after entities render.
         // ForgeRenderTypes.TRANSLUCENT_ON_PARTICLES_TARGET
         if(event.getStage() == RenderLevelStageEvent.Stage.AFTER_PARTICLES && BlazeMapConfig.CLIENT.clientFeatures.renderWaypointsInWorld.get()) {
-            Minecraft mc = Minecraft.getInstance();
             Entity playerCamera = mc.cameraEntity;
             PoseStack stack = event.getPoseStack();
             MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();
@@ -63,13 +67,11 @@ public class WaypointRenderer {
                     // To check if camera pointing towards the waypoint beam
                     final AABB fakeAABB = new AABB(pos).setMinY(level.getMinBuildHeight()).setMaxY(level.getMaxBuildHeight());
 
-                    if(Helpers.isInRenderDistance(playerHeightPos) && Helpers.isInFogDistance(playerHeightPos) && event.getFrustum().isVisible(fakeAABB)) {
+                    if(Helpers.isInRenderDistance(mc, playerHeightPos, true) && event.getFrustum().isVisible(fakeAABB)) {
                         renderWaypoint(mc, stack, buffers, w, posVec, playerCamera, partialTick);
                     }
                     else {
-                        // Waypoint is out of render distance. Render in furthest visible chunk instead
-                        float toEdgeOfRenderView = Math.min(RenderSystem.getShaderFogStart(), mc.options.getEffectiveRenderDistance() * 16);
-
+                        // Waypoint is out of view beyond fog/render distance. Render at the furthest visible block instead
                         // Find angle from player to waypoint
                         double xDelta = posVec.x() - playerCamera.getX();
                         double yDelta = posVec.y() - playerCamera.getY();

--- a/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
@@ -5,6 +5,8 @@ import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BeaconRenderer;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
@@ -22,9 +24,9 @@ import com.eerussianguy.blazemap.feature.waypoints.service.WaypointServiceClient
 import com.eerussianguy.blazemap.lib.Colors;
 import com.eerussianguy.blazemap.lib.Helpers;
 import com.eerussianguy.blazemap.lib.RenderHelper;
-import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.math.Matrix3f;
 import com.mojang.math.Matrix4f;
 import com.mojang.math.Vector3f;
 
@@ -44,6 +46,9 @@ public class WaypointRenderer {
         // Distance to furthest visible block, accounting for default sky fog.
         float toEdgeOfRenderView = Helpers.getRenderDistance(mc, true);
 
+        // To fade out the waypoint as we move on top of it
+        float proximityFadeOutDistSqr = 12 * 12;
+
         // Forge Doc:
         // Use this to render custom effects into the world, such as custom entity-like objects or special rendering effects. Called within a fabulous graphics target. Happens after entities render.
         // ForgeRenderTypes.TRANSLUCENT_ON_PARTICLES_TARGET
@@ -56,36 +61,71 @@ public class WaypointRenderer {
             if(playerCamera != null) {
                 Level level = playerCamera.level;
 
+                // For the frustum culling checks, to see the beacon when line of sight to base is blocked
+                final int waypointBeaconMinY = level.getMinBuildHeight() - 100;
+                final int waypointBeaconMaxY = BeaconRenderer.MAX_RENDER_Y;
+
                 WaypointServiceClient.instance().iterate(w -> {
                     final BlockPos pos = w.getPosition();
                     // TODO: Swap to just using a call to pos.getCenter() where needed in 1.19+
                     // (method not available in 1.18.2)
                     final Vec3 posVec = Vec3.atCenterOf(pos);
 
-                    // To not get cut off if the bottom of the world is out of the player's render distance
+                    // For distance checks, to ignore the Y component
                     final BlockPos playerHeightPos = pos.mutable().setY(playerCamera.getBlockY());
+
                     // To check if camera pointing towards the waypoint beam
-                    final AABB fakeAABB = new AABB(pos).setMinY(level.getMinBuildHeight()).setMaxY(level.getMaxBuildHeight());
+                    final AABB fakeAABB = new AABB(pos).setMinY(waypointBeaconMinY).setMaxY(waypointBeaconMaxY);
 
-                    if(Helpers.isInRenderDistance(mc, playerHeightPos, true) && event.getFrustum().isVisible(fakeAABB)) {
-                        renderWaypoint(mc, stack, buffers, w, posVec, playerCamera, partialTick);
-                    }
-                    else {
+                    final double waypointDistanceSqr = playerHeightPos.distToCenterSqr(playerCamera.position());
+                    final boolean isBeaconVisible = event.getFrustum().isVisible(fakeAABB);
+
+                    if (isBeaconVisible && waypointDistanceSqr < proximityFadeOutDistSqr) {
+                        // Fade out the waypoint as it approaches the camera, using the square distance for a nice quadratic fade
+                        renderWaypoint(mc, stack, buffers, w, posVec, playerCamera, partialTick, (float)(waypointDistanceSqr / proximityFadeOutDistSqr));
+
+                    } else if (isBeaconVisible && Helpers.isInRenderDistance(mc, playerHeightPos, true)) {
+                        renderWaypoint(mc, stack, buffers, w, posVec, playerCamera, partialTick, 1.0F);
+
+                    } else {
                         // Waypoint is out of view beyond fog/render distance. Render at the furthest visible block instead
-                        // Find angle from player to waypoint
-                        double xDelta = posVec.x() - playerCamera.getX();
-                        double yDelta = posVec.y() - playerCamera.getY();
-                        double zDelta = posVec.z() - playerCamera.getZ();
 
-                        // Project that angle onto the furthest visible chunk
-                        final Vec3 fakePos = new Vec3(xDelta, yDelta, zDelta)
-                            .normalize()
-                            .scale(toEdgeOfRenderView)
-                            .add(playerCamera.position());
+                        // Get unit vector representing angle towards waypoint location
+                        Vec3 normalisedPointVector = new Vec3(
+                            posVec.x() - playerCamera.getX(),
+                            posVec.y() - playerCamera.getY(),
+                            posVec.z() - playerCamera.getZ()
+                        ).normalize();
 
-                        final AABB fakerAABB = new AABB(new BlockPos(fakePos)).setMinY(level.getMinBuildHeight()).setMaxY(level.getMaxBuildHeight());
+                        // Get unit vector representing angle towards waypoint beam along x,z plane
+                        final Vec3 playerHeightPosVec = Vec3.atCenterOf(playerHeightPos);
+
+                        Vec3 normalisedBeamVector = new Vec3(
+                            playerHeightPosVec.x() - playerCamera.getX(),
+                            playerHeightPosVec.y() - playerCamera.getY(),
+                            playerHeightPosVec.z() - playerCamera.getZ()
+                        ).normalize();
+
+                        // Trig time! Find the y height at which the vector pointing towards the waypoint
+                        // intersects with the render-distance-adjusted waypoint beam:
+
+                        // Get y axis angle for waypoint: sin(angle) = y/1
+                        double angle = Math.asin(normalisedPointVector.y);
+                        // Knowing y axis angle + distance along x,z plane, get projected y height: tan(angle) = y/xzDist
+                        double yHeight = Math.tan(angle) * toEdgeOfRenderView;
+
+
+                        // Combine the projected y height with the adjusted beam x,z location, then reposition point relative to player
+                        Vec3 fakePos = new Vec3(
+                            normalisedBeamVector.x * toEdgeOfRenderView,
+                            yHeight,
+                            normalisedBeamVector.z * toEdgeOfRenderView
+                        ).add(playerCamera.position());
+
+                        final AABB fakerAABB = new AABB(new BlockPos(fakePos)).setMinY(waypointBeaconMinY).setMaxY(waypointBeaconMaxY);
+
                         if (event.getFrustum().isVisible(fakerAABB)) {
-                            renderWaypoint(mc, stack, buffers, w, fakePos, playerCamera, partialTick);
+                            renderWaypoint(mc, stack, buffers, w, fakePos, playerCamera, partialTick, 1.0F);
                         }
                     }
                 });
@@ -93,7 +133,7 @@ public class WaypointRenderer {
         }
     }
 
-    private static void renderWaypoint(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos, Entity playerCamera, float partialTick) {
+    private static void renderWaypoint(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos, Entity playerCamera, float partialTick, float alpha) {
         Level level = playerCamera.level;
         long gameTime = level.getGameTime();
         int minYHeight = level.getMinBuildHeight();
@@ -105,7 +145,7 @@ public class WaypointRenderer {
         translateFromCameraToPos(stack, lowestPos);
 
         final float[] colors = Colors.decomposeRGB(w.getColor());
-        BeaconRenderer.renderBeaconBeam(stack, buffers, BeaconRenderer.BEAM_LOCATION, partialTick, 1f, gameTime, 0, 1024, colors, 0.2f, 0.25f);
+        WaypointBeaconRenderer.renderBeaconBeam(stack, buffers, partialTick, 1f, gameTime, level.getMinBuildHeight(), BeaconRenderer.MAX_RENDER_Y, colors, alpha, 0.2f, 0.25f);
 
         stack.popPose();
 
@@ -152,5 +192,79 @@ public class WaypointRenderer {
     private static void translateFromCameraToPos(PoseStack stack, Vec3 pos) {
         Vec3 cam = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
         stack.translate(pos.x() - cam.x(), pos.y() - cam.y(), pos.z() - cam.z());
+    }
+
+    /**
+     * This whole class is primarily copying the code already in `BeaconRenderer` with some manual deobfuscation.
+     * I can't guarantee the variable naming is accurate in all places.
+     * 
+     * The goal here is just to remove the hardcoding of the alpha value so we can control it ourselves,
+     * so the waypoint can fade out as you move to stand on top of it.
+     * 
+     * Otherwise, the code is mostly kept the same as in the source with only minor adjustments
+     */
+    private static class WaypointBeaconRenderer extends BeaconRenderer {
+        private static final RenderType beaconBeam = RenderType.beaconBeam(BeaconRenderer.BEAM_LOCATION, true);
+
+        public WaypointBeaconRenderer(BlockEntityRendererProvider.Context p_173529_) {
+            super(p_173529_);
+        }
+
+        /**
+         * The `f` variables that remain, I can't figure out what exactly they're for. Leaving them as in the original code.
+         */
+        protected static void renderBeaconBeam(PoseStack stack, MultiBufferSource buffers, float partialTick, float p_112189_, long gameTime, int minY, int height, float[] colors, float alpha, float innerWidth, float outerWidth) {
+            int maxY = minY + height;
+
+            stack.pushPose();
+            stack.translate(0.5D, 0.0D, 0.5D);
+
+            float f = (float)Math.floorMod(gameTime, 40) + partialTick;
+            float f1 = height < 0 ? f : -f;
+            float f2 = Mth.frac(f1 * 0.2F - (float)Mth.floor(f1 * 0.1F));
+
+            float r = colors[0];
+            float g = colors[1];
+            float b = colors[2];
+
+            stack.pushPose();
+            stack.mulPose(Vector3f.YP.rotationDegrees(f * 2.25F - 45.0F));
+
+            float v1 = -1.0F + f2;
+            float v0 = (float)height * p_112189_ * (0.5F / innerWidth) + v1;
+
+            WaypointBeaconRenderer.renderPart(stack, buffers.getBuffer(WaypointBeaconRenderer.beaconBeam), r, g, b, alpha, minY, maxY, 0.0F, innerWidth, innerWidth, 0.0F, -innerWidth, 0.0F, 0.0F, -innerWidth, 0.0F, 1.0F, v0, v1);
+
+            stack.popPose();
+
+            v1 = -1.0F + f2;
+            v0 = (float)height * p_112189_ + v1;
+
+            WaypointBeaconRenderer.renderPart(stack, buffers.getBuffer(WaypointBeaconRenderer.beaconBeam), r, g, b, alpha * 0.125F, minY, maxY, -outerWidth, -outerWidth, outerWidth, -outerWidth, -outerWidth, outerWidth, outerWidth, outerWidth, 0.0F, 1.0F, v0, v1);
+
+            stack.popPose();
+        }
+
+        protected static void renderPart(PoseStack stack, VertexConsumer buffer, float r, float g, float b, float a, int minY, int maxY, float x0, float z0, float x1, float z1, float x2, float z2, float x3, float z3, float u0, float u1, float v0, float v1) {
+            PoseStack.Pose lastPose = stack.last();
+            Matrix4f matrix = lastPose.pose();
+            Matrix3f normal = lastPose.normal();
+
+            renderQuad(matrix, normal, buffer, r, g, b, a, maxY, minY, x0, z0, x1, z1, u0, u1, v0, v1);
+            renderQuad(matrix, normal, buffer, r, g, b, a, maxY, minY, x3, z3, x2, z2, u0, u1, v0, v1);
+            renderQuad(matrix, normal, buffer, r, g, b, a, maxY, minY, x1, z1, x3, z3, u0, u1, v0, v1);
+            renderQuad(matrix, normal, buffer, r, g, b, a, maxY, minY, x2, z2, x0, z0, u0, u1, v0, v1);
+        }
+
+        protected static void renderQuad(Matrix4f matrix, Matrix3f normal, VertexConsumer buffer, float r, float g, float b, float a, int y0, int y1, float x0, float z0, float x1, float z1, float u0, float u1, float v0, float v1) {
+            addVertex(matrix, normal, buffer, r, g, b, a, y0, x0, z0, u1, v0);
+            addVertex(matrix, normal, buffer, r, g, b, a, y1, x0, z0, u1, v1);
+            addVertex(matrix, normal, buffer, r, g, b, a, y1, x1, z1, u0, v1);
+            addVertex(matrix, normal, buffer, r, g, b, a, y0, x1, z1, u0, v0);
+        }
+
+        protected static void addVertex(Matrix4f matrix, Matrix3f normal, VertexConsumer buffer, float r, float g, float b, float a, int y, float x, float z, float u, float v) {
+            buffer.vertex(matrix, x, (float)y, z).color(r, g, b, a).uv(u, v).overlayCoords(OverlayTexture.NO_OVERLAY).uv2(15728880).normal(normal, 0.0F, 1.0F, 0.0F).endVertex();
+        }
     }
 }

--- a/src/main/java/com/eerussianguy/blazemap/lib/Helpers.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/Helpers.java
@@ -42,6 +42,7 @@ public class Helpers {
 
         if (isFogAdjusted) {
             renderDist *= Helpers.FOG_ADJUSTMENT_FACTOR;
+            renderDist -= 4;
         }
         return renderDist;
     }

--- a/src/main/java/com/eerussianguy/blazemap/lib/Helpers.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/Helpers.java
@@ -23,10 +23,43 @@ public class Helpers {
         return Minecraft.getInstance().player;
     }
 
-    public static boolean isInRenderDistance(BlockPos pos) {
-        Minecraft mc = Minecraft.getInstance();
+    // Fog adjustment factor based on the values used in FogRenderer::setupFog for the generic "in air" rendering case
+    private static final float FOG_ADJUSTMENT_FACTOR = 1F - 0.05F;
+
+    /** 
+     * Get the current render distance in blocks.
+     * 
+     * If isFogAdjusted == true, then the distance will be shrunk to compensate for the world fog
+     * at the boundary of the render distance, ensuring rendered objects are still visible.
+     * 
+     * Can pass in an existing mc object to save a lookup.
+     */
+    public static float getRenderDistance() { return getRenderDistance(Minecraft.getInstance(), false); }
+    public static float getRenderDistance(Minecraft mc) { return getRenderDistance(mc, false); }
+    public static float getRenderDistance(boolean isFogAdjusted) { return getRenderDistance(Minecraft.getInstance(), isFogAdjusted); }
+    public static float getRenderDistance(Minecraft mc, boolean isFogAdjusted) {
+        float renderDist = mc.options.getEffectiveRenderDistance() * 16;
+
+        if (isFogAdjusted) {
+            renderDist *= Helpers.FOG_ADJUSTMENT_FACTOR;
+        }
+        return renderDist;
+    }
+
+    /** 
+     * Check if pos is within render distance.
+     * 
+     * If isFogAdjusted == true, then the distance will be shrunk to compensate for the world fog
+     * at the boundary of the render distance, ensuring rendered objects are still visible.
+     * 
+     * Can pass in an existing mc object to save a lookup.
+     */
+    public static boolean isInRenderDistance(BlockPos pos) { return isInRenderDistance(Minecraft.getInstance(), pos, false); }
+    public static boolean isInRenderDistance(Minecraft mc, BlockPos pos) { return isInRenderDistance(mc, pos, false); }
+    public static boolean isInRenderDistance(BlockPos pos, boolean isFogAdjusted) { return isInRenderDistance(Minecraft.getInstance(), pos, false); }
+    public static boolean isInRenderDistance(Minecraft mc, BlockPos pos, boolean isFogAdjusted) {
         Entity entity = mc.cameraEntity;
-        double renderDist = mc.options.getEffectiveRenderDistance() * 16;
+        double renderDist = getRenderDistance(mc, isFogAdjusted);
         return entity != null && entity.blockPosition().distSqr(pos) < renderDist * renderDist;
     }
 


### PR DESCRIPTION
This PR just tackles the beam. Label issues are as yet untouched (will focus on next).

Changes:
- Changed so that when close to the waypoint beam, fade it out so it's not in the player's way.
- Fixing the distance at which the beam is rendered if the waypoint is out of render distance, 
  - Previous attempt using `RenderSystem.getShaderFogStart()` put the waypoints all up in your face when moving somewhere foggier like underwater.
  - Now, uses the value that Minecraft uses for `shaderFogStart` _in air_ specifically. In foggier places, beacon will just be out of view.
  - May return later to put the beam _in_ the fog when `shaderFogStart` is closer than the now hardcoded value.
- Fixing projected y height of waypoint that's beyond render distance
  - Previously, the distance at which the beam was rendered was measured between the player camera and the waypoint _point_, meaning the beam rendered closer than expected.
  - Trigged it out so the configured distance is to the waypoint _beam_, with the waypoint _point_ reprojected onto that beam at the correct angle.