### PR TITLE
BME-46 Fix waypoint label position

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,15 @@ dependencies {
 
     compileOnly "curse.maven:$rubidium_project_id:$rubidium_file_id"
 
-    implementation fg.deobf("curse.maven:$architectury_project_id:$architectury_file_id")
-    implementation fg.deobf("curse.maven:$ftbchunks_project_id:$ftbchunks_file_id")
-    implementation fg.deobf("curse.maven:$ftblib_project_id:$ftblib_file_id")
-    implementation fg.deobf("curse.maven:$ftbteams_project_id:$ftbteams_file_id")
+    compileOnly fg.deobf("curse.maven:$architectury_project_id:$architectury_file_id")
+    compileOnly fg.deobf("curse.maven:$ftbchunks_project_id:$ftbchunks_file_id")
+    compileOnly fg.deobf("curse.maven:$ftblib_project_id:$ftblib_file_id")
+    compileOnly fg.deobf("curse.maven:$ftbteams_project_id:$ftbteams_file_id")
+
+    // implementation fg.deobf("curse.maven:$architectury_project_id:$architectury_file_id")
+    // implementation fg.deobf("curse.maven:$ftbchunks_project_id:$ftbchunks_file_id")
+    // implementation fg.deobf("curse.maven:$ftblib_project_id:$ftblib_file_id")
+    // implementation fg.deobf("curse.maven:$ftbteams_project_id:$ftbteams_file_id")
 
     // Apply Mixin AP
     annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'

--- a/src/main/java/com/eerussianguy/blazemap/__deprecated/BlazeGui.java
+++ b/src/main/java/com/eerussianguy/blazemap/__deprecated/BlazeGui.java
@@ -55,27 +55,30 @@ public abstract class BlazeGui extends Screen {
         renderFrame(stack, buffers);
 
         stack.pushPose();
-        stack.translate(left, top, 0.05F);
-        if(title != EMPTY) {
-            renderLabel(stack, buffers, title, 12, 12, true);
-        }
-        renderComponents(stack, buffers);
+            stack.translate(left, top, 0.05F);
+
+            if(title != EMPTY) {
+                renderLabel(stack, buffers, title, 12, 12, true);
+            }
+
+            renderComponents(stack, buffers);
         stack.popPose();
         buffers.endBatch();
 
         stack.pushPose();
-        stack.translate(0, 0, 0.1F);
-        super.render(stack, i0, i1, f0);
+            stack.translate(0, 0, 0.1F);
+            super.render(stack, i0, i1, f0);
         stack.popPose();
 
         stack.pushPose();
-        float scale = (float) getMinecraft().getWindow().getGuiScale();
-        float unscale = 1F / scale;
-        stack.scale(unscale, unscale, 1);
-        stack.translate(0, 0, 0.5F);
-        buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        renderAbsolute(stack, buffers, scale);
-        buffers.endBatch();
+            float scale = (float) getMinecraft().getWindow().getGuiScale();
+            float unscale = 1F / scale;
+            stack.scale(unscale, unscale, 1);
+            stack.translate(0, 0, 0.5F);
+
+            buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
+            renderAbsolute(stack, buffers, scale);
+            buffers.endBatch();
         stack.popPose();
     }
 
@@ -83,8 +86,8 @@ public abstract class BlazeGui extends Screen {
 
     protected void renderFrame(PoseStack stack, MultiBufferSource buffers) {
         stack.pushPose();
-        stack.translate(left, top, 0);
-        RenderHelper.drawFrame(buffers.getBuffer(background), stack, guiWidth, guiHeight, 8);
+            stack.translate(left, top, 0);
+            RenderHelper.drawFrame(buffers.getBuffer(background), stack, guiWidth, guiHeight, 8);
         stack.popPose();
     }
 
@@ -96,8 +99,8 @@ public abstract class BlazeGui extends Screen {
 
     protected void renderSlot(PoseStack stack, MultiBufferSource buffers, int x, int y, int width, int height) {
         stack.pushPose();
-        stack.translate(x, y, 0);
-        RenderHelper.drawFrame(buffers.getBuffer(slot), stack, width, height, 1);
+            stack.translate(x, y, 0);
+            RenderHelper.drawFrame(buffers.getBuffer(slot), stack, width, height, 1);
         stack.popPose();
     }
 }

--- a/src/main/java/com/eerussianguy/blazemap/api/markers/Waypoint.java
+++ b/src/main/java/com/eerussianguy/blazemap/api/markers/Waypoint.java
@@ -8,6 +8,15 @@ import net.minecraft.world.level.Level;
 import com.eerussianguy.blazemap.api.BlazeMapReferences;
 
 public final class Waypoint extends Marker<Waypoint> {
+    // Track render state of waypoint in world
+    // TODO: Currently, nothing sets these values. Need to add both global client config options + individual options in Waypoint Editor,
+    // and also incorporate with save/restore.
+    // TODO: Integrate with WaypointGroup
+    private boolean showWaypointOnMap = true;
+    private boolean showWaypointInWorld = true;
+    private boolean showBeam = true;
+    private boolean showLabel = true;
+
     public Waypoint(ResourceLocation id, ResourceKey<Level> dimension, BlockPos position, String name) {
         this(id, dimension, position, name, BlazeMapReferences.Icons.WAYPOINT, -1);
         this.randomizeColor();
@@ -23,5 +32,45 @@ public final class Waypoint extends Marker<Waypoint> {
         setName(name);
         setColor(color);
         setNameVisible(true);
+    }
+
+    public boolean shouldRenderWaypointOnMap() {
+        return this.showWaypointOnMap;
+    }
+
+    public boolean shouldRenderWaypointInWorld() {
+        return this.showWaypointInWorld;
+    }
+
+    public boolean shouldShowBeam() {
+        return this.showWaypointInWorld && this.showBeam;
+    }
+
+    public boolean shouldShowLabel() {
+        return this.showWaypointInWorld && this.showLabel;
+    }
+
+
+    public Waypoint setShowWaypointOnMap(boolean showWaypointOnMap) {
+        this.showWaypointOnMap = showWaypointOnMap;
+        return this;
+    }
+
+    // TODO: I feel there should be some logic connecting setShowWaypointInWorld and setShowBeam + setShowLabel,
+    // considering the case when the former is true when the latter two are both set to false.
+    // But I don't know what it should be yet, so leaving them separate for now.
+    public Waypoint setShowWaypointInWorld(boolean showWaypointInWorld) {
+        this.showWaypointInWorld = showWaypointInWorld;
+        return this;
+    }
+
+    public Waypoint setShowBeam(boolean showBeam) {
+        this.showBeam = showBeam;
+        return this;
+    }
+
+    public Waypoint setShowLabel(boolean showLabel) {
+        this.showLabel = showLabel;
+        return this;
     }
 }

--- a/src/main/java/com/eerussianguy/blazemap/engine/render/MapRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/engine/render/MapRenderer.java
@@ -264,44 +264,45 @@ public class MapRenderer implements AutoCloseable {
         if(needsUpdate) updateTexture();
 
         stack.pushPose();
-        Matrix4f matrix = stack.last().pose();
+            Matrix4f matrix = stack.last().pose();
 
-        RenderHelper.fillRect(buffers, matrix, this.width, this.height, 0xFF333333);
-        RenderHelper.drawQuad(buffers.getBuffer(renderType), matrix, width, height);
+            RenderHelper.fillRect(buffers, matrix, this.width, this.height, 0xFF333333);
+            RenderHelper.drawQuad(buffers.getBuffer(renderType), matrix, width, height);
 
-        stack.pushPose();
-        ClientLevel level = Minecraft.getInstance().level;
-        for(var key : overlays_on) {
-            stack.translate(0, 0, 0.1f);
             stack.pushPose();
-            key.value().getMarkers(level, resolution).forEach(marker -> {
-                stack.translate(0, 0, 0.0001f);
-                renderObject(buffers, stack, marker, SearchTargeting.NONE);
-            });
+                ClientLevel level = Minecraft.getInstance().level;
+                for(var key : overlays_on) {
+                    stack.translate(0, 0, 0.1f);
+
+                    stack.pushPose();
+                        key.value().getMarkers(level, resolution).forEach(marker -> {
+                            stack.translate(0, 0, 0.0001f);
+                            renderObject(buffers, stack, marker, SearchTargeting.NONE);
+                        });
+                    stack.popPose();
+                }
             stack.popPose();
-        }
-        stack.popPose();
 
-        stack.pushPose();
-        if(hasActiveSearch) {
-            for(MapLabel l : labels_off) {
-                renderObject(buffers, stack, l, SearchTargeting.MISS);
-            }
-            for(MapLabel l : labels_on) {
-                renderObject(buffers, stack, l, SearchTargeting.HIT);
-            }
-        }
-        else {
-            for(MapLabel l : labels) {
-                renderObject(buffers, stack, l, SearchTargeting.NONE);
-            }
-        }
+            stack.pushPose();
+                if(hasActiveSearch) {
+                    for(MapLabel l : labels_off) {
+                        renderObject(buffers, stack, l, SearchTargeting.MISS);
+                    }
+                    for(MapLabel l : labels_on) {
+                        renderObject(buffers, stack, l, SearchTargeting.HIT);
+                    }
+                }
+                else {
+                    for(MapLabel l : labels) {
+                        renderObject(buffers, stack, l, SearchTargeting.NONE);
+                    }
+                }
 
-        LocalPlayer player = Helpers.getPlayer();
-        stack.translate(0, 0, 1);
-        playerMarker.setPosition(player.blockPosition()).setRotation(player.getRotationVector().y);
-        renderObject(buffers, stack, playerMarker, SearchTargeting.NONE);
-        stack.popPose();
+                LocalPlayer player = Helpers.getPlayer();
+                stack.translate(0, 0, 1);
+                playerMarker.setPosition(player.blockPosition()).setRotation(player.getRotationVector().y);
+                renderObject(buffers, stack, playerMarker, SearchTargeting.NONE);
+            stack.popPose();
 
         stack.popPose();
     }
@@ -423,13 +424,13 @@ public class MapRenderer implements AutoCloseable {
         if(!inRange(marker.getPosition())) return;
 
         stack.pushPose();
-        stack.scale((float) this.zoom, (float) this.zoom, 1);
-        BlockPos position = marker.getPosition();
-        int dx = position.getX() - begin.getX();
-        int dy = position.getZ() - begin.getZ();
-        stack.translate(dx, dy, 0);
+            stack.scale((float) this.zoom, (float) this.zoom, 1);
+            BlockPos position = marker.getPosition();
+            int dx = position.getX() - begin.getX();
+            int dy = position.getZ() - begin.getZ();
+            stack.translate(dx, dy, 0);
 
-        ((ObjectRenderer<Marker<?>>) marker.getRenderer().value()).render(marker, stack, buffers, this.zoom, search);
+            ((ObjectRenderer<Marker<?>>) marker.getRenderer().value()).render(marker, stack, buffers, this.zoom, search);
 
         stack.popPose();
     }

--- a/src/main/java/com/eerussianguy/blazemap/feature/IngameOverlays.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/IngameOverlays.java
@@ -28,17 +28,17 @@ public class IngameOverlays {
         if(!BlazeMapConfig.SERVER.mapItemRequirement.canPlayerAccessMap(Helpers.getPlayer(), ServerConfig.MapAccess.READ_LIVE)) return;
 
         stack.pushPose();
-        var buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        MinimapRenderer.INSTANCE.draw(stack, buffers, gui, width, height);
-        buffers.endBatch();
+            var buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
+            MinimapRenderer.INSTANCE.draw(stack, buffers, gui, width, height);
+            buffers.endBatch();
         stack.popPose();
     }
 
     public static void renderProfiler(ForgeIngameGui gui, PoseStack stack, float partialTicks, int width, int height) {
         stack.pushPose();
-        var buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        ProfilingRenderer.INSTANCE.draw(stack, buffers);
-        buffers.endBatch();
+            var buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
+            ProfilingRenderer.INSTANCE.draw(stack, buffers);
+            buffers.endBatch();
         stack.popPose();
     }
 }

--- a/src/main/java/com/eerussianguy/blazemap/feature/mapping/TerrainHeightLegend.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/mapping/TerrainHeightLegend.java
@@ -56,22 +56,25 @@ public class TerrainHeightLegend extends BaseComponent<TerrainHeightLegend> {
         RenderHelper.fillRect(buffers, stack.last().pose(), getWidth(), getHeight(), Colors.WIDGET_BACKGROUND);
 
         stack.pushPose();
-        stack.translate(16, BORDER, 0);
-        RenderHelper.drawQuad(buffers.getBuffer(getLegend()), stack.last().pose(), GRADIENT_WIDTH, legend.getHeight());
+            stack.translate(16, BORDER, 0);
+            RenderHelper.drawQuad(buffers.getBuffer(getLegend()), stack.last().pose(), GRADIENT_WIDTH, legend.getHeight());
         stack.popPose();
 
         var font = Minecraft.getInstance().font;
+
         stack.pushPose();
-        stack.translate(0, 2, 0);
-        stack.scale(TEXT_SCALE, TEXT_SCALE, 1);
-        for(int y = max; y >= min; y -= LABEL_STEP) {
-            String label = String.valueOf(y);
-            stack.pushPose();
-            stack.translate(getWidth() - font.width(label), 0, 0);
-            font.drawInBatch(label, 0, 0, Colors.WHITE, false, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
-            stack.popPose();
-            stack.translate(0, LABEL_STEP * TEXT_SCALE, 0);
-        }
+            stack.translate(0, 2, 0);
+            stack.scale(TEXT_SCALE, TEXT_SCALE, 1);
+            for(int y = max; y >= min; y -= LABEL_STEP) {
+                String label = String.valueOf(y);
+
+                stack.pushPose();
+                    stack.translate(getWidth() - font.width(label), 0, 0);
+                    font.drawInBatch(label, 0, 0, Colors.WHITE, false, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
+                stack.popPose();
+
+                stack.translate(0, LABEL_STEP * TEXT_SCALE, 0);
+            }
         stack.popPose();
 
         buffers.endBatch();

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/DefaultObjectRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/DefaultObjectRenderer.java
@@ -41,9 +41,9 @@ public class DefaultObjectRenderer implements ObjectRenderer<Marker<?>> {
             Minecraft mc = Minecraft.getInstance();
 
             stack.pushPose();
-            stack.translate(-mc.font.width(name), (10 + (height / scale)), 0);
-            stack.scale(scale, scale, 0);
-            mc.font.drawInBatch(name, 0, 0, search.color(color), true, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
+                stack.translate(-mc.font.width(name), (10 + (height / scale)), 0);
+                stack.scale(scale, scale, 0);
+                mc.font.drawInBatch(name, 0, 0, search.color(color), true, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
             stack.popPose();
         }
 

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/MDInspectorWidget.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/MDInspectorWidget.java
@@ -49,33 +49,35 @@ public class MDInspectorWidget<MD extends MasterDatum> implements Widget, GuiEve
 
     @Override
     public void render(PoseStack stack, int i0, int i1, float f0) {
-        stack.pushPose();
         Window window = Minecraft.getInstance().getWindow();
         float scale = 1F / (float) window.getGuiScale();
-        stack.scale(scale, scale, 1);
 
-        stack.translate(posX, posY, 2);
-        stack.scale(WIDGET_SCALE, WIDGET_SCALE, 1);
-        stack.translate(-sizeX / 2, -sizeY / 2, 0);
+        stack.pushPose();
+            stack.scale(scale, scale, 1);
 
-        RenderHelper.fillRect(stack.last().pose(), sizeX, sizeY, Colors.WIDGET_BACKGROUND);
-        renderTitleBar(stack);
-        stack.translate(0, 15, 0);
-        if(controller == null) {
-            font.draw(stack, "No MDInspectionController found!", 7, 7, 0xFFFFAAAA);
-        } else {
-            renderMD(stack);
-        }
+            stack.translate(posX, posY, 2);
+            stack.scale(WIDGET_SCALE, WIDGET_SCALE, 1);
+            stack.translate(-sizeX / 2, -sizeY / 2, 0);
+
+            RenderHelper.fillRect(stack.last().pose(), sizeX, sizeY, Colors.WIDGET_BACKGROUND);
+            renderTitleBar(stack);
+            stack.translate(0, 15, 0);
+
+            if(controller == null) {
+                font.draw(stack, "No MDInspectionController found!", 7, 7, 0xFFFFAAAA);
+            } else {
+                renderMD(stack);
+            }
 
         stack.popPose();
     }
 
     private void renderTitleBar(PoseStack stack) {
         stack.pushPose();
-        RenderHelper.fillRect(stack.last().pose(), sizeX, 13, Colors.WIDGET_BACKGROUND);
-        font.draw(stack, String.format("%s [%d, %d]", datum.getID().location, chunkPos.x, chunkPos.z), 2, 4, Colors.WHITE);
-        stack.translate(sizeX - 13, 0, 0);
-        RenderHelper.fillRect(stack.last().pose(), 13, 13, 0xFFFF0000);
+            RenderHelper.fillRect(stack.last().pose(), sizeX, 13, Colors.WIDGET_BACKGROUND);
+            font.draw(stack, String.format("%s [%d, %d]", datum.getID().location, chunkPos.x, chunkPos.z), 2, 4, Colors.WHITE);
+            stack.translate(sizeX - 13, 0, 0);
+            RenderHelper.fillRect(stack.last().pose(), 13, 13, 0xFFFF0000);
         stack.popPose();
     }
 
@@ -85,22 +87,27 @@ public class MDInspectorWidget<MD extends MasterDatum> implements Widget, GuiEve
             font.draw(stack, string, 2, 0, Colors.WHITE);
             stack.translate(0, 10, 0);
         }
+
         stack.translate(2, 0, 0);
+        
         for(int grid = 0; grid < controller.getNumGrids(datum); grid++) {
             stack.translate(0, 12, 0);
             font.draw(stack, controller.getGridName(datum, grid), 0, -10, Colors.WHITE);
+            
             for(int z = 0; z < 16; z++) {
                 stack.pushPose();
-                for(int x = 0; x < 16; x++) {
-                    ResourceLocation icon = controller.getIcon(datum, grid, x, z);
-                    int tint = controller.getTint(datum, grid, x, z);
-                    if(icon == null) {
-                        RenderHelper.fillRect(stack.last().pose(), 16, 16, tint);
-                    } else {
-                        RenderHelper.drawTexturedQuad(icon, tint, stack, 0, 0, 16, 16);
+                    for(int x = 0; x < 16; x++) {
+                        ResourceLocation icon = controller.getIcon(datum, grid, x, z);
+                        int tint = controller.getTint(datum, grid, x, z);
+
+                        if(icon == null) {
+                            RenderHelper.fillRect(stack.last().pose(), 16, 16, tint);
+                        } else {
+                            RenderHelper.drawTexturedQuad(icon, tint, stack, 0, 0, 16, 16);
+                        }
+                        
+                        stack.translate(16, 0, 0);
                     }
-                    stack.translate(16, 0, 0);
-                }
                 stack.popPose();
                 stack.translate(0, 16, 0);
             }

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/MinimapRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/MinimapRenderer.java
@@ -44,11 +44,13 @@ public class MinimapRenderer implements AutoCloseable {
 
         // Prepare to render minimap
         Profilers.Minimap.DRAW_TIME_PROFILER.begin();
-        stack.pushPose();
         float scale = (float) (1F / mc.getWindow().getGuiScale());
-        stack.scale(scale, scale, 1);
-        minimap.render(stack, buffers);
+
+        stack.pushPose();
+            stack.scale(scale, scale, 1);
+            minimap.render(stack, buffers);
         stack.popPose();
+
         Profilers.Minimap.DRAW_TIME_PROFILER.end();
     }
 

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/MinimapWidget.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/MinimapWidget.java
@@ -52,8 +52,8 @@ public class MinimapWidget {
         stack.translate(posX, posY, 0);
 
         stack.pushPose();
-        stack.translate(-BORDER_SIZE, -BORDER_SIZE, 0);
-        RenderHelper.fillRect(stack.last().pose(), width + BORDER_SIZE*2, height + BORDER_SIZE*2, Colors.WIDGET_BACKGROUND);
+            stack.translate(-BORDER_SIZE, -BORDER_SIZE, 0);
+            RenderHelper.fillRect(stack.last().pose(), width + BORDER_SIZE*2, height + BORDER_SIZE*2, Colors.WIDGET_BACKGROUND);
         stack.popPose();
 
         RenderHelper.renderWithScissorNative(posX, posY, width, height, () -> {
@@ -62,10 +62,10 @@ public class MinimapWidget {
 
         if(editor){
             stack.pushPose();
-            stack.translate(0, height - HANDLE_SIZE - BORDER_SIZE, 0);
-            RenderHelper.fillRect(buffers, stack.last().pose(), HANDLE_SIZE + BORDER_SIZE, HANDLE_SIZE + BORDER_SIZE, Colors.WIDGET_BACKGROUND);
-            stack.translate(0, BORDER_SIZE, 0.1);
-            RenderHelper.fillRect(buffers, stack.last().pose(), HANDLE_SIZE, HANDLE_SIZE, 0xFFFF0000);
+                stack.translate(0, height - HANDLE_SIZE - BORDER_SIZE, 0);
+                RenderHelper.fillRect(buffers, stack.last().pose(), HANDLE_SIZE + BORDER_SIZE, HANDLE_SIZE + BORDER_SIZE, Colors.WIDGET_BACKGROUND);
+                stack.translate(0, BORDER_SIZE, 0.1);
+                RenderHelper.fillRect(buffers, stack.last().pose(), HANDLE_SIZE, HANDLE_SIZE, 0xFFFF0000);
             stack.popPose();
         }
 
@@ -76,12 +76,12 @@ public class MinimapWidget {
             int length = font.width(coords);
 
             stack.pushPose();
-            stack.translate(width / 2, height + BORDER_SIZE * 2, 0);
-            stack.scale(2, 2, 1);
-            stack.translate(-COORDS_BORDER - ((float)length) / 2F, 0, 0);
+                stack.translate(width / 2, height + BORDER_SIZE * 2, 0);
+                stack.scale(2, 2, 1);
+                stack.translate(-COORDS_BORDER - ((float)length) / 2F, 0, 0);
 
-            RenderHelper.fillRect(buffers, stack.last().pose(), length + COORDS_BORDER*2, font.lineHeight - 2 + COORDS_BORDER*2, Colors.WIDGET_BACKGROUND);
-            font.drawInBatch(coords, COORDS_BORDER, COORDS_BORDER, Colors.WHITE, false, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
+                RenderHelper.fillRect(buffers, stack.last().pose(), length + COORDS_BORDER*2, font.lineHeight - 2 + COORDS_BORDER*2, Colors.WIDGET_BACKGROUND);
+                font.drawInBatch(coords, COORDS_BORDER, COORDS_BORDER, Colors.WHITE, false, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
             stack.popPose();
         }
     }

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/WorldMapPopup.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/WorldMapPopup.java
@@ -193,16 +193,16 @@ public class WorldMapPopup implements Widget {
     @Override
     public void render(PoseStack stack, int i0, int i1, float f0) {
         stack.pushPose();
+            stack.translate(posX, posY, 1);
 
-        stack.translate(posX, posY, 1);
+            RenderHelper.fillRect(stack.last().pose(), sizeX, sizeY, Colors.WIDGET_BACKGROUND);
+            for(PopupItem item : items) {
+                stack.pushPose();
+                    item.render(stack, sizeX, item == lastClicked, item == hovered);
+                stack.popPose();
 
-        RenderHelper.fillRect(stack.last().pose(), sizeX, sizeY, Colors.WIDGET_BACKGROUND);
-        for(PopupItem item : items) {
-            stack.pushPose();
-            item.render(stack, sizeX, item == lastClicked, item == hovered);
-            stack.popPose();
-            stack.translate(0, PopupItem.HEIGHT, 0);
-        }
+                stack.translate(0, PopupItem.HEIGHT, 0);
+            }
 
         stack.popPose();
 
@@ -255,9 +255,9 @@ public class WorldMapPopup implements Widget {
             if(icon != null) RenderHelper.drawTexturedQuad(icon, enabled ? iconTint : color, stack, 2,4, 16, 16);
 
             stack.pushPose();
-            stack.scale(2, 2, 1);
-            font.draw(stack, text, 10, 3, color);
-            if(folder) font.draw(stack, ">", (width/2) - 8, 3, color);
+                stack.scale(2, 2, 1);
+                font.draw(stack, text, 10, 3, color);
+                if(folder) font.draw(stack, ">", (width/2) - 8, 3, color);
             stack.popPose();
         }
 

--- a/src/main/java/com/eerussianguy/blazemap/feature/maps/ui/MapScaleDisplay.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/maps/ui/MapScaleDisplay.java
@@ -29,16 +29,16 @@ public class MapScaleDisplay extends Image {
     public void render(PoseStack stack, boolean hasMouse, int mouseX, int mouseY) {
         super.render(stack, hasMouse, mouseX, mouseY);
 
-        stack.pushPose();
         double z = renderer.getZoom();
         float w = getWidth();
         float h = getHeight() - font.lineHeight;
 
         String zoom = z > 1 ? String.format("%.0f : 1", z) : String.format("1 : %.0f", 1 / z);
         String distance = String.format("%dm", (int) (size / renderer.getZoom()));
-        font.draw(stack, zoom, (w-font.width(zoom))/2, h/2 - 8, Colors.NO_TINT);
-        font.draw(stack, distance, (w-font.width(distance))/2, h/2 + 8, Colors.NO_TINT);
 
+        stack.pushPose();
+            font.draw(stack, zoom, (w-font.width(zoom))/2, h/2 - 8, Colors.NO_TINT);
+            font.draw(stack, distance, (w-font.width(distance))/2, h/2 + 8, Colors.NO_TINT);
         stack.popPose();
     }
 

--- a/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
@@ -114,7 +114,7 @@ public class WaypointRenderer {
     private static void renderWaypoint(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos, Level level, float partialTick, float alpha) {
         stack.pushPose();
             if (w.shouldShowBeam()) renderWaypointBeam(stack, buffers, level, partialTick, w, pos, alpha);
-            if (w.shouldShowLabel()) renderWaypointLabel(mc, stack, buffers, w, pos);
+            if (w.shouldShowLabel()) renderWaypointLabel(mc, stack, buffers, w, pos, alpha);
         stack.popPose();
     }
 
@@ -122,8 +122,8 @@ public class WaypointRenderer {
         long gameTime = level.getGameTime();
         int minYHeight = level.getMinBuildHeight();
         
-        // To render beam from the bottom of the world
-        final Vec3 lowestPos = new Vec3(pos.x(), minYHeight, pos.z());
+        // To render beam from the bottom of the world. Also, undoing block centring because it messes with beam render location.
+        final Vec3 lowestPos = new Vec3(pos.x(), minYHeight, pos.z()).add(-0.5, 0, -0.5);
 
         stack.pushPose();
             translateFromCameraToPos(stack, lowestPos);
@@ -133,11 +133,10 @@ public class WaypointRenderer {
         stack.popPose();
     }
 
-
     /**
      * <a href="https://www.wolframalpha.com/input?i=quadratic+fit+calculator&assumption=%7B%22F%22%2C+%22QuadraticFitCalculator%22%2C+%22data2%22%7D+-%3E%22%7B%7B460%2C+0.0282%7D%2C+%7B7100%2C+0.108%7D%2C+%7B14375%2C+0.1253%7D%7D%22">https://www.wolframalpha.com/input?i=quadratic+fit+calculator&assumption=%7B%22F%22%2C+%22QuadraticFitCalculator%22%2C+%22data2%22%7D+-%3E%22%7B%7B460%2C+0.0282%7D%2C+%7B7100%2C+0.108%7D%2C+%7B14375%2C+0.1253%7D%7D%22</a>
      */
-    private static void renderWaypointLabel(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos) {
+    private static void renderWaypointLabel(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos, float alpha) {
         String name = w.getName();
         RenderType icon = RenderType.text(w.getIcon());
         Camera camera = mc.gameRenderer.getMainCamera();
@@ -145,6 +144,9 @@ public class WaypointRenderer {
         // Note: Where do these values come from?
         float width = 32;
         float height = 32;
+
+        // Minecraft's fontsize is hardcoded. So having to manually define a scale multiplier to change the relative fontsize
+        float fontHeightScale = 2;
 
         stack.pushPose();
 
@@ -154,27 +156,41 @@ public class WaypointRenderer {
             Vec3 camPos = camera.getPosition();
             double dist = camPos.distanceToSqr(pos);
 
-            float distScale = Mth.clampedMap((float) dist, 0f, 128f * 128f, 0f, 1f);
-            distScale = (float) ((-6.92782E-10 * distScale * distScale) + (0.0000172555 * distScale) + 0.0204091);
-            distScale *= 4f;
+            // TODO: Adjust this dynamically to limit scaling with distance
+            float distScale = 1f/16f;
+            // float distScale = Mth.clampedMap((float) dist, 0f, 128f * 128f, 0f, 1f);
+            // distScale = (float) ((-6.92782E-10 * distScale * distScale) + (0.0000172555 * distScale) + 0.0204091);
+            // distScale *= 4f;
 
             stack.scale(distScale, distScale, distScale);
             stack.mulPose(Vector3f.ZP.rotationDegrees(180f));
-            stack.translate(0f, 0f, -20f);
 
+            // Draw label text
             if(name != null) {
                 stack.pushPose();
 
-                    stack.translate(-mc.font.width(name), (-60 + (height / 2)), 0);
-                    stack.scale(2, 2, 0);
+                    // Move starting point up above the icon
+                    stack.translate(0, -4 - (height * 0.5), 0);
+
+                    // Make font size bigger (because scaling is the only way Mojang's given us to do so)
+                    stack.scale(fontHeightScale, fontHeightScale, 0);
+
+                    // Put the text into position
+                    stack.translate(-mc.font.width(name) * 0.5, -mc.font.lineHeight, 0);
                     mc.font.drawInBatch(name, 0, 0, w.getColor(), true, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
-                    
+
                 stack.popPose();
             }
 
-            stack.translate(-width / 2, -height / 2, 0);
-            VertexConsumer iconBuffer = buffers.getBuffer(icon);
-            RenderHelper.drawQuad(iconBuffer, stack.last().pose(), width, height, w.getColor());
+            // Draw icon
+            stack.pushPose();
+
+                // Centre icon then draw it
+                stack.translate(-width * 0.5, -height * 0.5, 0);
+                VertexConsumer iconBuffer = buffers.getBuffer(icon);
+                RenderHelper.drawQuad(iconBuffer, stack.last().pose(), width, height, w.getColor());
+
+            stack.popPose();
 
         stack.popPose();
     }

--- a/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java
@@ -1,5 +1,6 @@
 package com.eerussianguy.blazemap.feature.waypoints;
 
+import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -16,6 +17,8 @@ import net.minecraft.world.phys.Vec3;
 import net.minecraftforge.client.event.RenderLevelStageEvent;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.eventbus.api.IEventBus;
+
+import javax.annotation.Nonnull;
 
 import com.eerussianguy.blazemap.api.markers.Waypoint;
 import com.eerussianguy.blazemap.config.BlazeMapConfig;
@@ -34,14 +37,29 @@ public class WaypointRenderer {
 
     public static void init() {
         IEventBus bus = MinecraftForge.EVENT_BUS;
-
         bus.addListener(WaypointRenderer::onLevelStageRender);
     }
 
     public static void onLevelStageRender(RenderLevelStageEvent event) {
-        if(!BlazeMapConfig.SERVER.mapItemRequirement.canPlayerAccessMap(Helpers.getPlayer(), ServerConfig.MapAccess.READ_LIVE)) return;
+        // Forge Doc:
+        // Use this to render custom effects into the world, such as custom entity-like objects or special rendering effects. Called within a fabulous graphics target. Happens after entities render.
+        // ForgeRenderTypes.TRANSLUCENT_ON_PARTICLES_TARGET
+        
+        // Note: Due to a bug somewhere causing weird offsets in Creative but not Spectator mode, 
+        // have to render in the earlier `AFTER_TRANSLUCENT_BLOCKS` stage in 1.18.2. 
+        // Check if can move back to `AFTER_PARTICLES` stage when porting to newer versions.
+        if(event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) return;
 
-        Minecraft mc = Minecraft.getInstance();
+        if(!BlazeMapConfig.SERVER.mapItemRequirement.canPlayerAccessMap(Helpers.getPlayer(), ServerConfig.MapAccess.READ_LIVE)) return;
+        if(!BlazeMapConfig.CLIENT.clientFeatures.renderWaypointsInWorld.get()) return;
+
+        Minecraft mc = Minecraft.getInstance();        
+        Entity playerCamera = mc.cameraEntity;
+
+        if (playerCamera == null) return;
+
+        Level level = playerCamera.level;
+        float partialTick = event.getPartialTick();
 
         // Distance to furthest visible block, accounting for default sky fog.
         float toEdgeOfRenderView = Helpers.getRenderDistance(mc, true);
@@ -49,149 +67,164 @@ public class WaypointRenderer {
         // To fade out the waypoint as we move on top of it
         float proximityFadeOutDistSqr = 12 * 12;
 
-        // Forge Doc:
-        // Use this to render custom effects into the world, such as custom entity-like objects or special rendering effects. Called within a fabulous graphics target. Happens after entities render.
-        // ForgeRenderTypes.TRANSLUCENT_ON_PARTICLES_TARGET
-        if(event.getStage() == RenderLevelStageEvent.Stage.AFTER_PARTICLES && BlazeMapConfig.CLIENT.clientFeatures.renderWaypointsInWorld.get()) {
-            Entity playerCamera = mc.cameraEntity;
-            PoseStack stack = event.getPoseStack();
-            MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();
-            float partialTick = event.getPartialTick();
+        // For the frustum culling checks, to see the beacon when line of sight to base is blocked
+        final int waypointBeaconMinY = level.getMinBuildHeight() - 100;
+        final int waypointBeaconMaxY = BeaconRenderer.MAX_RENDER_Y;
 
-            if(playerCamera != null) {
-                Level level = playerCamera.level;
+        PoseStack stack = event.getPoseStack();
+        MultiBufferSource.BufferSource buffers = mc.renderBuffers().bufferSource();
 
-                // For the frustum culling checks, to see the beacon when line of sight to base is blocked
-                final int waypointBeaconMinY = level.getMinBuildHeight() - 100;
-                final int waypointBeaconMaxY = BeaconRenderer.MAX_RENDER_Y;
+        WaypointServiceClient.instance().iterate(w -> {
+            if (!w.shouldRenderWaypointInWorld()) return;
 
-                WaypointServiceClient.instance().iterate(w -> {
-                    final BlockPos pos = w.getPosition();
-                    // TODO: Swap to just using a call to pos.getCenter() where needed in 1.19+
-                    // (method not available in 1.18.2)
-                    final Vec3 posVec = Vec3.atCenterOf(pos);
+            final BlockPos pos = w.getPosition();
+            // TODO: Swap to just using a call to pos.getCenter() where needed in 1.19+
+            // (method not available in 1.18.2)
+            final Vec3 posVec = Vec3.atCenterOf(pos);
 
-                    // For distance checks, to ignore the Y component
-                    final BlockPos playerHeightPos = pos.mutable().setY(playerCamera.getBlockY());
+            // For distance checks, to ignore the Y component
+            final BlockPos playerHeightPos = pos.mutable().setY(playerCamera.getBlockY());
 
-                    // To check if camera pointing towards the waypoint beam
-                    final AABB fakeAABB = new AABB(pos).setMinY(waypointBeaconMinY).setMaxY(waypointBeaconMaxY);
+            // To check if camera pointing towards the waypoint beam
+            final AABB fakeAABB = new AABB(pos).setMinY(waypointBeaconMinY).setMaxY(waypointBeaconMaxY);
 
-                    final double waypointDistanceSqr = playerHeightPos.distToCenterSqr(playerCamera.position());
-                    final boolean isBeaconVisible = event.getFrustum().isVisible(fakeAABB);
+            final boolean isBeaconVisible = event.getFrustum().isVisible(fakeAABB);
+            final double waypointDistanceSqr = playerHeightPos.distToCenterSqr(playerCamera.position());
 
-                    if (isBeaconVisible && waypointDistanceSqr < proximityFadeOutDistSqr) {
-                        // Fade out the waypoint as it approaches the camera, using the square distance for a nice quadratic fade
-                        renderWaypoint(mc, stack, buffers, w, posVec, playerCamera, partialTick, (float)(waypointDistanceSqr / proximityFadeOutDistSqr));
+            if (isBeaconVisible && waypointDistanceSqr < proximityFadeOutDistSqr) {
+                // Fade out the waypoint as it approaches the camera, using the square distance for a nice quadratic fade
+                renderWaypoint(mc, stack, buffers, w, posVec, level, partialTick, (float)(waypointDistanceSqr / proximityFadeOutDistSqr));
 
-                    } else if (isBeaconVisible && Helpers.isInRenderDistance(mc, playerHeightPos, true)) {
-                        renderWaypoint(mc, stack, buffers, w, posVec, playerCamera, partialTick, 1.0F);
+            } else if (isBeaconVisible && Helpers.isInRenderDistance(mc, playerHeightPos, true)) {
+                renderWaypoint(mc, stack, buffers, w, posVec, level, partialTick, 1.0F);
 
-                    } else {
-                        // Waypoint is out of view beyond fog/render distance. Render at the furthest visible block instead
+            } else {
+                // Waypoint is out of view beyond fog/render distance. Render at the furthest visible block instead
+                Vec3 fakePos = getFakeWaypointPos(playerCamera, posVec, playerHeightPos, toEdgeOfRenderView);
 
-                        // Get unit vector representing angle towards waypoint location
-                        Vec3 normalisedPointVector = new Vec3(
-                            posVec.x() - playerCamera.getX(),
-                            posVec.y() - playerCamera.getY(),
-                            posVec.z() - playerCamera.getZ()
-                        ).normalize();
+                final AABB fakerAABB = new AABB(new BlockPos(fakePos)).setMinY(waypointBeaconMinY).setMaxY(waypointBeaconMaxY);
 
-                        // Get unit vector representing angle towards waypoint beam along x,z plane
-                        final Vec3 playerHeightPosVec = Vec3.atCenterOf(playerHeightPos);
-
-                        Vec3 normalisedBeamVector = new Vec3(
-                            playerHeightPosVec.x() - playerCamera.getX(),
-                            playerHeightPosVec.y() - playerCamera.getY(),
-                            playerHeightPosVec.z() - playerCamera.getZ()
-                        ).normalize();
-
-                        // Trig time! Find the y height at which the vector pointing towards the waypoint
-                        // intersects with the render-distance-adjusted waypoint beam:
-
-                        // Get y axis angle for waypoint: sin(angle) = y/1
-                        double angle = Math.asin(normalisedPointVector.y);
-                        // Knowing y axis angle + distance along x,z plane, get projected y height: tan(angle) = y/xzDist
-                        double yHeight = Math.tan(angle) * toEdgeOfRenderView;
-
-
-                        // Combine the projected y height with the adjusted beam x,z location, then reposition point relative to player
-                        Vec3 fakePos = new Vec3(
-                            normalisedBeamVector.x * toEdgeOfRenderView,
-                            yHeight,
-                            normalisedBeamVector.z * toEdgeOfRenderView
-                        ).add(playerCamera.position());
-
-                        final AABB fakerAABB = new AABB(new BlockPos(fakePos)).setMinY(waypointBeaconMinY).setMaxY(waypointBeaconMaxY);
-
-                        if (event.getFrustum().isVisible(fakerAABB)) {
-                            renderWaypoint(mc, stack, buffers, w, fakePos, playerCamera, partialTick, 1.0F);
-                        }
-                    }
-                });
+                if (event.getFrustum().isVisible(fakerAABB)) {
+                    renderWaypoint(mc, stack, buffers, w, fakePos, level, partialTick, 1.0F);
+                }
             }
-        }
+        });
     }
 
-    private static void renderWaypoint(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos, Entity playerCamera, float partialTick, float alpha) {
-        Level level = playerCamera.level;
+    private static void renderWaypoint(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos, Level level, float partialTick, float alpha) {
+        stack.pushPose();
+            if (w.shouldShowBeam()) renderWaypointBeam(stack, buffers, level, partialTick, w, pos, alpha);
+            if (w.shouldShowLabel()) renderWaypointLabel(mc, stack, buffers, w, pos);
+        stack.popPose();
+    }
+
+    private static void renderWaypointBeam(PoseStack stack, MultiBufferSource.BufferSource buffers, Level level, float partialTick, Waypoint w,  Vec3 pos, float alpha) {
         long gameTime = level.getGameTime();
         int minYHeight = level.getMinBuildHeight();
-
+        
         // To render beam from the bottom of the world
         final Vec3 lowestPos = new Vec3(pos.x(), minYHeight, pos.z());
 
         stack.pushPose();
-        translateFromCameraToPos(stack, lowestPos);
+            translateFromCameraToPos(stack, lowestPos);
 
-        final float[] colors = Colors.decomposeRGB(w.getColor());
-        WaypointBeaconRenderer.renderBeaconBeam(stack, buffers, partialTick, 1f, gameTime, level.getMinBuildHeight(), BeaconRenderer.MAX_RENDER_Y, colors, alpha, 0.2f, 0.25f);
-
+            final float[] colors = Colors.decomposeRGB(w.getColor());
+            WaypointBeaconRenderer.renderBeaconBeam(stack, buffers, partialTick, 1f, gameTime, 0, BeaconRenderer.MAX_RENDER_Y, colors, alpha, 0.2f, 0.25f);
         stack.popPose();
-
-        // Labels
-        stack.pushPose();
-        renderLabel(mc, stack, buffers, w, pos);
-
-        stack.popPose();
-
     }
+
 
     /**
      * <a href="https://www.wolframalpha.com/input?i=quadratic+fit+calculator&assumption=%7B%22F%22%2C+%22QuadraticFitCalculator%22%2C+%22data2%22%7D+-%3E%22%7B%7B460%2C+0.0282%7D%2C+%7B7100%2C+0.108%7D%2C+%7B14375%2C+0.1253%7D%7D%22">https://www.wolframalpha.com/input?i=quadratic+fit+calculator&assumption=%7B%22F%22%2C+%22QuadraticFitCalculator%22%2C+%22data2%22%7D+-%3E%22%7B%7B460%2C+0.0282%7D%2C+%7B7100%2C+0.108%7D%2C+%7B14375%2C+0.1253%7D%7D%22</a>
      */
-    private static void renderLabel(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos) {
-        stack.pushPose();
+    private static void renderWaypointLabel(Minecraft mc, PoseStack stack, MultiBufferSource.BufferSource buffers, Waypoint w, Vec3 pos) {
+        String name = w.getName();
+        RenderType icon = RenderType.text(w.getIcon());
+        Camera camera = mc.gameRenderer.getMainCamera();
+
+        // Note: Where do these values come from?
         float width = 32;
         float height = 32;
-        translateFromCameraToPos(stack, pos);
-        stack.mulPoseMatrix(new Matrix4f(mc.gameRenderer.getMainCamera().rotation()));
-        Vec3 cam = mc.gameRenderer.getMainCamera().getPosition();
-        double dist = cam.distanceToSqr(pos);
-        float scale = Mth.clampedMap((float) dist, 0f, 128f * 128f, 0f, 1f);
-        scale = (float) ((-6.92782E-10 * scale * scale) + (0.0000172555 * scale) + 0.0204091);
-        scale *= 4f;
-        stack.scale(scale, scale, scale);
-        stack.mulPose(Vector3f.ZP.rotationDegrees(180f));
-        stack.translate(0f, 0f, -20f);
-        String name = w.getName();
-        if(name != null) {
-            stack.pushPose();
-            stack.translate(-mc.font.width(name), (-60 + (height / 2)), 0);
-            stack.scale(2, 2, 0);
-            mc.font.drawInBatch(name, 0, 0, w.getColor(), true, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
-            stack.popPose();
-        }
-        stack.translate(-width / 2, -height / 2, 0);
-        VertexConsumer vertices = buffers.getBuffer(RenderType.text(w.getIcon()));
-        RenderHelper.drawQuad(vertices, stack.last().pose(), width, height, w.getColor());
+
+        stack.pushPose();
+
+            translateFromPosToPos(stack, camera.getPosition(), pos);
+            stack.mulPoseMatrix(new Matrix4f(camera.rotation()));
+            
+            Vec3 camPos = camera.getPosition();
+            double dist = camPos.distanceToSqr(pos);
+
+            float distScale = Mth.clampedMap((float) dist, 0f, 128f * 128f, 0f, 1f);
+            distScale = (float) ((-6.92782E-10 * distScale * distScale) + (0.0000172555 * distScale) + 0.0204091);
+            distScale *= 4f;
+
+            stack.scale(distScale, distScale, distScale);
+            stack.mulPose(Vector3f.ZP.rotationDegrees(180f));
+            stack.translate(0f, 0f, -20f);
+
+            if(name != null) {
+                stack.pushPose();
+
+                    stack.translate(-mc.font.width(name), (-60 + (height / 2)), 0);
+                    stack.scale(2, 2, 0);
+                    mc.font.drawInBatch(name, 0, 0, w.getColor(), true, stack.last().pose(), buffers, false, 0, LightTexture.FULL_BRIGHT);
+                    
+                stack.popPose();
+            }
+
+            stack.translate(-width / 2, -height / 2, 0);
+            VertexConsumer iconBuffer = buffers.getBuffer(icon);
+            RenderHelper.drawQuad(iconBuffer, stack.last().pose(), width, height, w.getColor());
+
         stack.popPose();
     }
 
     @SuppressWarnings("resource")
-    private static void translateFromCameraToPos(PoseStack stack, Vec3 pos) {
-        Vec3 cam = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
-        stack.translate(pos.x() - cam.x(), pos.y() - cam.y(), pos.z() - cam.z());
+    private static void translateFromCameraToPos(PoseStack stack, Vec3 targetPos) {
+        Vec3 camPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
+        translateFromPosToPos(stack, camPos, targetPos);
+    }
+
+    @SuppressWarnings("resource")
+    private static void translateFromPosToPos(PoseStack stack, Vec3 fromPos, Vec3 toPos) {
+        stack.translate(toPos.x() - fromPos.x(), toPos.y() - fromPos.y(), toPos.z() - fromPos.z());
+    }
+
+    /**
+     * Project the waypoint pos to a point at the edge of the current cylindrical render distance
+     */
+    private static Vec3 getFakeWaypointPos(Entity playerCamera, Vec3 posVec, @Nonnull BlockPos playerHeightPos, float toEdgeOfRenderView) {
+        // Get unit vector representing angle towards waypoint location
+        Vec3 normalisedPointVector = new Vec3(
+            posVec.x() - playerCamera.getX(),
+            posVec.y() - playerCamera.getY(),
+            posVec.z() - playerCamera.getZ()
+        ).normalize();
+
+        // Get unit vector representing angle towards waypoint beam along x,z plane
+        final Vec3 playerHeightPosVec = Vec3.atCenterOf(playerHeightPos);
+
+        Vec3 normalisedBeamVector = new Vec3(
+            playerHeightPosVec.x() - playerCamera.getX(),
+            playerHeightPosVec.y() - playerCamera.getY(),
+            playerHeightPosVec.z() - playerCamera.getZ()
+        ).normalize();
+
+        // Trig time! Find the y height at which the vector pointing towards the waypoint
+        // intersects with the render-distance-adjusted waypoint beam:
+
+        // Get y axis angle for waypoint: sin(angle) = y/1
+        double angle = Math.asin(normalisedPointVector.y);
+        // Knowing y axis angle + distance along x,z plane, get projected y height: tan(angle) = y/xzDist
+        double yHeight = Math.tan(angle) * toEdgeOfRenderView;
+
+
+        // Combine the projected y height with the adjusted beam x,z location, then reposition point relative to player
+        return new Vec3(
+            normalisedBeamVector.x * toEdgeOfRenderView,
+            yHeight,
+            normalisedBeamVector.z * toEdgeOfRenderView
+        ).add(playerCamera.position());
     }
 
     /**
@@ -217,30 +250,29 @@ public class WaypointRenderer {
             int maxY = minY + height;
 
             stack.pushPose();
-            stack.translate(0.5D, 0.0D, 0.5D);
+                stack.translate(0.5D, 0.0D, 0.5D);
 
-            float f = (float)Math.floorMod(gameTime, 40) + partialTick;
-            float f1 = height < 0 ? f : -f;
-            float f2 = Mth.frac(f1 * 0.2F - (float)Mth.floor(f1 * 0.1F));
+                float f = (float)Math.floorMod(gameTime, 40) + partialTick;
+                float f1 = height < 0 ? f : -f;
+                float f2 = Mth.frac(f1 * 0.2F - (float)Mth.floor(f1 * 0.1F));
 
-            float r = colors[0];
-            float g = colors[1];
-            float b = colors[2];
+                float r = colors[0];
+                float g = colors[1];
+                float b = colors[2];
 
-            stack.pushPose();
-            stack.mulPose(Vector3f.YP.rotationDegrees(f * 2.25F - 45.0F));
+                stack.pushPose();
+                    stack.mulPose(Vector3f.YP.rotationDegrees(f * 2.25F - 45.0F));
 
-            float v1 = -1.0F + f2;
-            float v0 = (float)height * p_112189_ * (0.5F / innerWidth) + v1;
+                    float v1 = -1.0F + f2;
+                    float v0 = (float)height * p_112189_ * (0.5F / innerWidth) + v1;
 
-            WaypointBeaconRenderer.renderPart(stack, buffers.getBuffer(WaypointBeaconRenderer.beaconBeam), r, g, b, alpha, minY, maxY, 0.0F, innerWidth, innerWidth, 0.0F, -innerWidth, 0.0F, 0.0F, -innerWidth, 0.0F, 1.0F, v0, v1);
+                    WaypointBeaconRenderer.renderPart(stack, buffers.getBuffer(WaypointBeaconRenderer.beaconBeam), r, g, b, alpha, minY, maxY, 0.0F, innerWidth, innerWidth, 0.0F, -innerWidth, 0.0F, 0.0F, -innerWidth, 0.0F, 1.0F, v0, v1);
+                stack.popPose();
 
-            stack.popPose();
+                v1 = -1.0F + f2;
+                v0 = (float)height * p_112189_ + v1;
 
-            v1 = -1.0F + f2;
-            v0 = (float)height * p_112189_ + v1;
-
-            WaypointBeaconRenderer.renderPart(stack, buffers.getBuffer(WaypointBeaconRenderer.beaconBeam), r, g, b, alpha * 0.125F, minY, maxY, -outerWidth, -outerWidth, outerWidth, -outerWidth, -outerWidth, outerWidth, outerWidth, outerWidth, 0.0F, 1.0F, v0, v1);
+                WaypointBeaconRenderer.renderPart(stack, buffers.getBuffer(WaypointBeaconRenderer.beaconBeam), r, g, b, alpha * 0.125F, minY, maxY, -outerWidth, -outerWidth, outerWidth, -outerWidth, -outerWidth, outerWidth, outerWidth, outerWidth, 0.0F, 1.0F, v0, v1);
 
             stack.popPose();
         }

--- a/src/main/java/com/eerussianguy/blazemap/feature/waypoints/ui/WaypointGroupNode.java
+++ b/src/main/java/com/eerussianguy/blazemap/feature/waypoints/ui/WaypointGroupNode.java
@@ -45,13 +45,16 @@ public class WaypointGroupNode extends WaypointTreeNode {
     @Override
     public void render(PoseStack stack, boolean hasMouse, int mouseX, int mouseY) {
         renderFlatBackground(stack, 0xFF444444);
+
         if(group.management.canCreateChild) {
             RenderHelper.drawTexturedQuad(ADD, Colors.NO_TINT, stack, add.getPositionX(), add.getPositionY(), add.getWidth(), add.getHeight());
         }
+
         stack.pushPose();
-        stack.translate(getHeight(), getHeight() / 2F - 4, 0);
-        font.draw(stack, open ? "v" : ">", -9, 1, Colors.BLACK);
+            stack.translate(getHeight(), getHeight() / 2F - 4, 0);
+            font.draw(stack, open ? "v" : ">", -9, 1, Colors.BLACK);
         stack.popPose();
+
         super.render(stack, hasMouse, mouseX, mouseY);
     }
 

--- a/src/main/java/com/eerussianguy/blazemap/lib/RenderHelper.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/RenderHelper.java
@@ -4,6 +4,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LightTexture;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.MultiBufferSource.BufferSource;
 import net.minecraft.resources.ResourceLocation;
 
 import com.eerussianguy.blazemap.BlazeMap;
@@ -67,16 +68,17 @@ public class RenderHelper {
     }
 
     public static void renderChromaticGradient(PoseStack stack, float w, float h){
-        var buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
-        stack.pushPose();
-        w /= 6;
+        BufferSource buffers = MultiBufferSource.immediate(Tesselator.getInstance().getBuilder());
         VertexConsumer vertices = buffers.getBuffer(RenderHelper.SOLID);
-        for(int i = 0; i < 6; i++) {
-            int colorA = CHROMA[ i % 6 ], colorB = CHROMA[ (i+1) % 6 ];
-            Matrix4f matrix = stack.last().pose();
-            renderGradient(vertices, matrix, w, h, colorA, colorB, colorB, colorA);
-            stack.translate(w, 0, 0);
-        }
+        w /= 6;
+
+        stack.pushPose();
+            for(int i = 0; i < 6; i++) {
+                int colorA = CHROMA[ i % 6 ], colorB = CHROMA[ (i+1) % 6 ];
+                Matrix4f matrix = stack.last().pose();
+                renderGradient(vertices, matrix, w, h, colorA, colorB, colorB, colorA);
+                stack.translate(w, 0, 0);
+            }
         stack.popPose();
         buffers.endBatch();
     }
@@ -115,27 +117,27 @@ public class RenderHelper {
     public static void drawFrame(VertexConsumer vertices, PoseStack stack, int width, int height, int border, int color) {
         stack.pushPose();
 
-        drawQuad(vertices, stack.last().pose(), border, border, color, 0F, 0.25F, 0F, 0.25F);
-        stack.translate(border, 0, 0);
-        drawQuad(vertices, stack.last().pose(), width - (border * 2), border, color, 0.25F, 0.75F, 0F, 0.25F);
-        stack.translate(width - (border * 2), 0, 0);
-        drawQuad(vertices, stack.last().pose(), border, border, color, 0.75F, 1F, 0F, 0.25F);
+            drawQuad(vertices, stack.last().pose(), border, border, color, 0F, 0.25F, 0F, 0.25F);
+            stack.translate(border, 0, 0);
+            drawQuad(vertices, stack.last().pose(), width - (border * 2), border, color, 0.25F, 0.75F, 0F, 0.25F);
+            stack.translate(width - (border * 2), 0, 0);
+            drawQuad(vertices, stack.last().pose(), border, border, color, 0.75F, 1F, 0F, 0.25F);
 
-        stack.translate(-width + border, border, 0);
+            stack.translate(-width + border, border, 0);
 
-        drawQuad(vertices, stack.last().pose(), border, height - (border * 2), color, 0F, 0.25F, 0.25F, 0.75F);
-        stack.translate(border, 0, 0);
-        drawQuad(vertices, stack.last().pose(), width - (border * 2), height - (border * 2), color, 0.25F, 0.75F, 0.25F, 0.75F);
-        stack.translate(width - (border * 2), 0, 0);
-        drawQuad(vertices, stack.last().pose(), border, height - (border * 2), color, 0.75F, 1F, 0.25F, 0.75F);
+            drawQuad(vertices, stack.last().pose(), border, height - (border * 2), color, 0F, 0.25F, 0.25F, 0.75F);
+            stack.translate(border, 0, 0);
+            drawQuad(vertices, stack.last().pose(), width - (border * 2), height - (border * 2), color, 0.25F, 0.75F, 0.25F, 0.75F);
+            stack.translate(width - (border * 2), 0, 0);
+            drawQuad(vertices, stack.last().pose(), border, height - (border * 2), color, 0.75F, 1F, 0.25F, 0.75F);
 
-        stack.translate(-width + border, height - (border * 2), 0);
+            stack.translate(-width + border, height - (border * 2), 0);
 
-        drawQuad(vertices, stack.last().pose(), border, border, color, 0F, 0.25F, 0.75F, 1F);
-        stack.translate(border, 0, 0);
-        drawQuad(vertices, stack.last().pose(), width - (border * 2), border, color, 0.25F, 0.75F, 0.75F, 1F);
-        stack.translate(width - (border * 2), 0, 0);
-        drawQuad(vertices, stack.last().pose(), border, border, color, 0.75F, 1F, 0.75F, 1F);
+            drawQuad(vertices, stack.last().pose(), border, border, color, 0F, 0.25F, 0.75F, 1F);
+            stack.translate(border, 0, 0);
+            drawQuad(vertices, stack.last().pose(), width - (border * 2), border, color, 0.25F, 0.75F, 0.75F, 1F);
+            stack.translate(width - (border * 2), 0, 0);
+            drawQuad(vertices, stack.last().pose(), border, border, color, 0.75F, 1F, 0.75F, 1F);
 
         stack.popPose();
     }

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/components/HueSlider.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/components/HueSlider.java
@@ -11,9 +11,9 @@ public class HueSlider extends Slider {
 
     protected void renderBackground(PoseStack stack, boolean hasMouse, int mouseX, int mouseY) {
         stack.pushPose();
-        renderFocusableFlatBackground(stack);
-        stack.translate(1, 1, 0);
-        RenderHelper.renderChromaticGradient(stack, getWidth() - 2, getHeight() - 2);
+            renderFocusableFlatBackground(stack);
+            stack.translate(1, 1, 0);
+            RenderHelper.renderChromaticGradient(stack, getWidth() - 2, getHeight() - 2);
         stack.popPose();
     }
 

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/components/IconTabs.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/components/IconTabs.java
@@ -30,38 +30,41 @@ public class IconTabs extends BaseComponent<IconTabs> implements BorderedCompone
     public void render(PoseStack stack, boolean hasMouse, int mouseX, int mouseY) {
         //render bottom line
         stack.pushPose();
-        stack.translate(-begin, getHeight() - 1, 0);
-        RenderHelper.fillRect(stack.last().pose(), getWidth() + begin + end, 1, Colors.UNFOCUSED);
+            stack.translate(-begin, getHeight() - 1, 0);
+            RenderHelper.fillRect(stack.last().pose(), getWidth() + begin + end, 1, Colors.UNFOCUSED);
         stack.popPose();
 
         // render tabs
         for(var tab : tabs) {
-            stack.pushPose();
-            stack.translate(tab.getPositionX(), tab.getPositionY(), 0);
             var item = tab.component;
 
-            if(tab == active) { // render active tab
-                renderBorderedBox(stack, -1, -1, tab.getWidth()+2, tab.getHeight()+2, Colors.UNFOCUSED, Colors.BLACK);
-                stack.pushPose();
-                stack.translate(0, tab.getHeight(), 0);
-                RenderHelper.fillRect(stack.last().pose(), tab.getWidth(), 1, 0xFF303030);
-                stack.popPose();
-                Minecraft.getInstance().font.draw(stack, item.getName(), size + 2, size / 2f - 4, Colors.WHITE);
-            }
-            else { // render inactive tabs
-                renderBorderedBox(stack, -1, 0, tab.getWidth()+2, tab.getHeight()+1, Colors.UNFOCUSED, Colors.BLACK);
+            stack.pushPose();
+                stack.translate(tab.getPositionX(), tab.getPositionY(), 0);
 
-                // hover only for inactive tabs
-                if(hasMouse && tab.mouseIntercepts(mouseX, mouseY)) {
+                if(tab == active) { // render active tab
+                    renderBorderedBox(stack, -1, -1, tab.getWidth()+2, tab.getHeight()+2, Colors.UNFOCUSED, Colors.BLACK);
+                    
                     stack.pushPose();
-                    stack.translate(0, 1, 0);
-                    RenderHelper.fillRect(stack.last().pose(), tab.getWidth(), tab.getHeight()-1, 0xFF222222); // render hover
+                        stack.translate(0, tab.getHeight(), 0);
+                        RenderHelper.fillRect(stack.last().pose(), tab.getWidth(), 1, 0xFF303030);
                     stack.popPose();
+                    
+                    Minecraft.getInstance().font.draw(stack, item.getName(), size + 2, size / 2f - 4, Colors.WHITE);
                 }
-            }
+                else { // render inactive tabs
+                    renderBorderedBox(stack, -1, 0, tab.getWidth()+2, tab.getHeight()+1, Colors.UNFOCUSED, Colors.BLACK);
 
-            // render icon
-            RenderHelper.drawTexturedQuad(item.getIcon(), item.getIconTint(), stack, 1, 1, size-2, size-2);
+                    // hover only for inactive tabs
+                    if(hasMouse && tab.mouseIntercepts(mouseX, mouseY)) {
+                        stack.pushPose();
+                            stack.translate(0, 1, 0);
+                            RenderHelper.fillRect(stack.last().pose(), tab.getWidth(), tab.getHeight()-1, 0xFF222222); // render hover
+                        stack.popPose();
+                    }
+                }
+
+                // render icon
+                RenderHelper.drawTexturedQuad(item.getIcon(), item.getIconTint(), stack, 1, 1, size-2, size-2);
 
             stack.popPose();
         }

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/components/SBPicker.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/components/SBPicker.java
@@ -49,8 +49,8 @@ public class SBPicker extends BaseComponent<SBPicker> implements FocusableCompon
         renderFocusableFlatBackground(stack);
 
         stack.pushPose();
-        stack.translate(1, 1, 0);
-        RenderHelper.renderGradient(stack, getWidth() - 2, getHeight() - 2, Colors.WHITE, fullColor, Colors.BLACK, Colors.BLACK);
+            stack.translate(1, 1, 0);
+            RenderHelper.renderGradient(stack, getWidth() - 2, getHeight() - 2, Colors.WHITE, fullColor, Colors.BLACK, Colors.BLACK);
         stack.popPose();
 
         stack.translate(0, 0, 0.1F);

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/components/selection/SelectionGrid.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/components/selection/SelectionGrid.java
@@ -95,10 +95,10 @@ public class SelectionGrid<T> extends BaseComponent<SelectionGrid<T>> implements
                 int px = col * grain, py = row * grain;
                 if(element.equals(selected)) {
                     stack.pushPose();
-                    stack.translate(px-1, py-1, 0);
-                    RenderHelper.fillRect(stack.last().pose(), size+2, size+2, 0xFFFFDD00);
-                    stack.translate(1, 1, 0);
-                    RenderHelper.fillRect(stack.last().pose(), size, size, Colors.BLACK);
+                        stack.translate(px-1, py-1, 0);
+                        RenderHelper.fillRect(stack.last().pose(), size+2, size+2, 0xFFFFDD00);
+                        stack.translate(1, 1, 0);
+                        RenderHelper.fillRect(stack.last().pose(), size, size, Colors.BLACK);
                     stack.popPose();
                 }
                 RenderHelper.drawTexturedQuad(image.apply(element), Colors.NO_TINT, stack, px, py, size, size);

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/core/BaseComponent.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/core/BaseComponent.java
@@ -38,24 +38,24 @@ public abstract class BaseComponent<T extends BaseComponent<T>> extends Position
     @Override
     public final void render(PoseStack stack, int mouseX, int mouseY, float partial) {
         if(!isVisible()) return;
+
         BaseComponent.partial = partial;
-        stack.pushPose();
-
         boolean hasMouse = mouseIntercepts(mouseX, mouseY);
-
         int positionX = getPositionX(), positionY = getPositionY();
-        if(getReferenceFrame() == ReferenceFrame.GLOBAL) {
-            stack.translate(positionX, positionY, 0);
-            mouseX -= positionX;
-            mouseY -= positionY;
-        }
 
-        this.render(stack, hasMouse, mouseX, mouseY);
+        stack.pushPose();
+            if(getReferenceFrame() == ReferenceFrame.GLOBAL) {
+                stack.translate(positionX, positionY, 0);
+                mouseX -= positionX;
+                mouseY -= positionY;
+            }
 
-        stack.translate(0, 0, 100);
-        if(hasMouse && Minecraft.getInstance().screen instanceof TooltipService service) {
-            this.renderTooltip(stack, mouseX, mouseY, service);
-        }
+            this.render(stack, hasMouse, mouseX, mouseY);
+
+            stack.translate(0, 0, 100);
+            if(hasMouse && Minecraft.getInstance().screen instanceof TooltipService service) {
+                this.renderTooltip(stack, mouseX, mouseY, service);
+            }
 
         stack.popPose();
     }

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/core/BaseContainer.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/core/BaseContainer.java
@@ -64,9 +64,10 @@ public abstract class BaseContainer<T extends BaseContainer<T>> extends BaseComp
         getComponentAt(mouseX, mouseY, ReferenceFrame.PARENT).ifPresent(child -> {
             int childX = child.getPositionX();
             int childY = child.getPositionY();
+
             stack.pushPose();
-            stack.translate(childX, childY, 0.1);
-            child.renderTooltipAsChild(stack, mouseX - childX, mouseY - childY, service);
+                stack.translate(childX, childY, 0.1);
+                child.renderTooltipAsChild(stack, mouseX - childX, mouseY - childY, service);
             stack.popPose();
         });
     }
@@ -75,11 +76,12 @@ public abstract class BaseContainer<T extends BaseContainer<T>> extends BaseComp
     public void render(PoseStack stack, boolean hasMouse, int mouseX, int mouseY) {
         renderBackground(stack, hasMouse, mouseX, mouseY);
         for(var child : renderables) {
-            stack.pushPose();
             int childX = child.getPositionX(), childY = child.getPositionY();
             int childMouseX = mouseX - childX, childMouseY = mouseY - childY;
-            stack.translate(childX, childY, 0.1);
-            child.renderAsChild(stack, hasMouse && child.mouseIntercepts(childMouseX, childMouseY), childMouseX, childMouseY);
+
+            stack.pushPose();
+                stack.translate(childX, childY, 0.1);
+                child.renderAsChild(stack, hasMouse && child.mouseIntercepts(childMouseX, childMouseY), childMouseX, childMouseY);
             stack.popPose();
         }
     }

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/core/MetaContainer.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/core/MetaContainer.java
@@ -30,13 +30,14 @@ public class MetaContainer extends BaseContainer<MetaContainer> {
     @Override
     public void render(PoseStack stack, boolean hasMouse, int mouseX, int mouseY) {
         stack.pushPose();
-        for(var layer : renderables) {
-            stack.translate(0, 0, 25);
-            stack.pushPose();
-            layer.renderAsChild(stack, hasMouse, mouseX, mouseY);
-            stack.popPose();
-        }
-        stack.pushPose();
+            for(var layer : renderables) {
+                stack.translate(0, 0, 25);
+
+                stack.pushPose();
+                    layer.renderAsChild(stack, hasMouse, mouseX, mouseY);
+                stack.popPose();
+            }
+        stack.popPose();
     }
 
     @Override

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/fragment/HostWindowComponent.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/fragment/HostWindowComponent.java
@@ -62,10 +62,10 @@ public class HostWindowComponent extends LineContainer {
 
             // close button
             stack.pushPose();
-            stack.translate(close.getPositionX(), close.getPositionY(), 0);
-            int red = (hasMouse && close.mouseIntercepts(mouseX, mouseY)) ? 0xFFFF4444 : 0xFFFF0000;
-            RenderHelper.fillRect(stack.last().pose(), close.getWidth(), close.getHeight(), red);
-            mc.font.draw(stack, "x", 2.5F, 0.5F, Colors.WHITE);
+                stack.translate(close.getPositionX(), close.getPositionY(), 0);
+                int red = (hasMouse && close.mouseIntercepts(mouseX, mouseY)) ? 0xFFFF4444 : 0xFFFF0000;
+                RenderHelper.fillRect(stack.last().pose(), close.getWidth(), close.getHeight(), red);
+                mc.font.draw(stack, "x", 2.5F, 0.5F, Colors.WHITE);
             stack.popPose();
 
             // title

--- a/src/main/java/com/eerussianguy/blazemap/lib/gui/trait/BorderedComponent.java
+++ b/src/main/java/com/eerussianguy/blazemap/lib/gui/trait/BorderedComponent.java
@@ -31,12 +31,13 @@ public interface BorderedComponent {
 
     default void renderBorderedBox(PoseStack stack, float posX, float posY, int w, int h, int border, int background) {
         stack.pushPose();
-        if(posX != 0 || posY != 0) {
-            stack.translate(posX, posY, 0);
-        }
-        RenderHelper.fillRect(stack.last().pose(), w, h, border);
-        stack.translate(1, 1, 0);
-        RenderHelper.fillRect(stack.last().pose(), w - 2, h - 2, background);
+            if(posX != 0 || posY != 0) {
+                stack.translate(posX, posY, 0);
+            }
+
+            RenderHelper.fillRect(stack.last().pose(), w, h, border);
+            stack.translate(1, 1, 0);
+            RenderHelper.fillRect(stack.last().pose(), w - 2, h - 2, background);
         stack.popPose();
     }
 

--- a/src/main/java/com/eerussianguy/blazemap/profiling/overlay/Container.java
+++ b/src/main/java/com/eerussianguy/blazemap/profiling/overlay/Container.java
@@ -69,8 +69,9 @@ public class Container implements IDrawable {
         for(IDrawable element : children){
             if(element.isDisabled()) continue;
             stack.pushPose();
-            element.draw(stack, buffers, fontRenderer);
+                element.draw(stack, buffers, fontRenderer);
             stack.popPose();
+            
             stack.translate(0, element.getHeight(), 0);
         }
     }

--- a/src/main/java/com/eerussianguy/blazemap/profiling/overlay/ProfilingRenderer.java
+++ b/src/main/java/com/eerussianguy/blazemap/profiling/overlay/ProfilingRenderer.java
@@ -104,14 +104,15 @@ public class ProfilingRenderer {
         if(Helpers.getPlayer() == null) return;
 
         Profilers.DEBUG_TIME_PROFILER.begin();
+        double guiScale = mc.getWindow().getGuiScale();
 
         stack.pushPose();
-        double guiScale = mc.getWindow().getGuiScale();
-        if(guiScale > DEBUG_SCALE){
-            stack.scale((float)(DEBUG_SCALE / guiScale), (float)(DEBUG_SCALE / guiScale), 1);
-        }
-        stack.translate(5, 5, 0);
-        drawPanels(stack, buffers, mc.font);
+            if(guiScale > DEBUG_SCALE){
+                stack.scale((float)(DEBUG_SCALE / guiScale), (float)(DEBUG_SCALE / guiScale), 1);
+            }
+
+            stack.translate(5, 5, 0);
+            drawPanels(stack, buffers, mc.font);
         stack.popPose();
 
         Profilers.DEBUG_TIME_PROFILER.end();
@@ -120,9 +121,11 @@ public class ProfilingRenderer {
     private void drawPanels(PoseStack stack, MultiBufferSource buffers, Font fontRenderer) {
         for(Container panel : PANELS){
             if(panel.isDisabled()) continue;
+
             stack.pushPose();
-            panel.draw(stack, buffers, fontRenderer);
+                panel.draw(stack, buffers, fontRenderer);
             stack.popPose();
+
             stack.translate(Container.PANEL_WIDTH + 5, 0, 0);
         }
     }

--- a/src/main/java/com/eerussianguy/blazemap/profiling/overlay/SubsystemProfile.java
+++ b/src/main/java/com/eerussianguy/blazemap/profiling/overlay/SubsystemProfile.java
@@ -26,9 +26,11 @@ public class SubsystemProfile extends Container {
         stack.translate(0, style.margin, 0);
         for(IDrawable element : children){
             if(element.isDisabled()) continue;
+
             stack.pushPose();
-            element.draw(stack, buffers, fontRenderer);
+                element.draw(stack, buffers, fontRenderer);
             stack.popPose();
+
             stack.translate(0, element.getHeight(), 0);
         }
         String label = metric == null ? name : String.format("%s : %s", name, metric.get());


### PR DESCRIPTION
Just a fix for the positional bugs. Not tackling the aesthetics of the sizing yet, that'll be for a follow up.

A lot of this PR is me indenting all content between pairs of ` stack.pushPose();` and ` stack.popPose();` to verify that they were indeed paired up. As such, I suggest clicking the "Hode Whitespace" option before reviewing this to substantially cut down on the noise!

Most of the meaningful changes are in `src/main/java/com/eerussianguy/blazemap/feature/waypoints/WaypointRenderer.java`, with some additional meaningful changes in `src/main/java/com/eerussianguy/blazemap/api/markers/Waypoint.java`. I also realise that my refactoring has made the diff a PITA to read, so am happy to walk through it instead if you want. Though granted, I did most of the big refactoring a few months ago, so memory of exactly what changed and why may be foggy 😅

---

## Before
<img width="2256" height="1398" alt="2026-06-05_00 18 29" src="https://github.com/user-attachments/assets/654e17e3-c1c4-4f5e-ad52-709dbc7d8007" />

## After
<img width="2256" height="1398" alt="2026-06-04_23 39 43" src="https://github.com/user-attachments/assets/30604860-b324-407f-8b82-f436a0dd5351" />
